### PR TITLE
fix: route segments parsing with multiple parameters

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,7 +24,7 @@ const regularRoutes = Object.keys(ROUTES).reduce<Route[]>((routes, key) => {
   const segments = key
     .replace(/\/src\/pages|\.tsx$/g, '')
     .replace(/\[\.{3}.+\]/, '*')
-    .replace(/\[(.+)\]/, ':$1')
+    .replace(/\[([^\]]+)\]/g, ':$1')
     .split('/')
     .filter(Boolean)
 


### PR DESCRIPTION
## Parsing output

##### `src/pages/jobs/[status]/[id].tsx`:
  - Current: `['jobs', ':status]', '[id']`
  - Expected: `['jobs', ':status', ':id']`

##### `src/pages/jobs/[status].[id].tsx`:
  - Current: `['jobs', ':status].[id']`
  - Expected: `['jobs', ':status.:id']`