### PR TITLE
feat(router): add ability to add user-provided routes and aliases

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,7 +69,8 @@ const App = preservedRoutes?.['_app'] || Fragment
 const NotFound = preservedRoutes?.['404'] || Fragment
 
 const location = new ReactLocation()
-const fileRoutes = [...regularRoutes, { path: '*', element: <NotFound /> }]
+const catchAll = { path: '*', element: <NotFound /> }
+const fileRoutes = [...regularRoutes]
 type Props = Omit<RouterProps, 'children' | 'location' | 'routes'> &
   Partial<Pick<RouterProps, 'routes'>> & { aliases?: RouteAliases[] }
 export const Routes = (props: Props = { routes: [] }) => {
@@ -87,6 +88,7 @@ export const Routes = (props: Props = { routes: [] }) => {
         }
       })
     }
+    knownRoutes.push(catchAll)
     return knownRoutes
   }, [props.routes, props.aliases])
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,7 +70,8 @@ const NotFound = preservedRoutes?.['404'] || Fragment
 
 const location = new ReactLocation()
 const fileRoutes = [...regularRoutes, { path: '*', element: <NotFound /> }]
-type Props = Omit<RouterProps, 'children' | 'location'> & { aliases?: RouteAliases[] }
+type Props = Omit<RouterProps, 'children' | 'location' | 'routes'> &
+  Partial<Pick<RouterProps, 'routes'>> & { aliases?: RouteAliases[] }
 export const Routes = (props: Props = { routes: [] }) => {
   const routes = useMemo(() => {
     const knownRoutes = [...(props.routes || []), ...fileRoutes]


### PR DESCRIPTION
Adds the ability to provide route aliases and to provide additional custom routes that aren't file path based.

I am running into this issue because I'm trying to build a chrome extension where it will always load the schema `chrome://id/index.html`, and I need to `/index.html` to `/`.