### PR TITLE
fix(routes): ensure proper ordering of un-nested layout files

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -69,6 +69,6 @@ export const generateRegularRoutes = <T extends BaseRoute, M>(
       return parent
     }, {} as BaseRoute)
 
-    return routes
+    return routes.sort((a, b) => (b.path?.length || 0) - (a.path?.length || 0))
   }, [])
 }


### PR DESCRIPTION
- this ensures un-nested layouts appear ahead of their common parent when there is a shared segment at the beginning of the route

With the following directory structure and un-nested layout files

```
src/pages
├── 📄 _app.tsx
├── 🗂 companies
│  ├── 🗂 [company_id]
│  └── 📄 [company_id].tsx
├── 📄 companies.[company_id].offer_letters.[offer_letter_id].create.tsx
├── 📄 companies.[company_id].offer_letters.[offer_letter_id].edit.tsx
└── 📄 index.tsx
```

Before the change, you can see the order is incorrect which causes react-location to search for the nested folder before the un-nested layout:

![Screen Shot 2022-11-05 at 10 25 42 AM](https://user-images.githubusercontent.com/69559/200124593-f39a6c3d-a67a-4281-b800-b7d0a21dd092.png)

After the change to sorting, the routes are ordered correctly, allowing the un-nested layout to take priority and render correctly:

![Screen Shot 2022-11-05 at 10 29 57 AM](https://user-images.githubusercontent.com/69559/200124798-f8914557-b88e-42d9-bd80-acee0db0c988.png)

