### PR TITLE
feat: support ErrorBoundary as errorElement

### DIFF
--- a/src/react-router.tsx
+++ b/src/react-router.tsx
@@ -5,7 +5,7 @@ import type { ActionFunction, RouteObject, LoaderFunction } from 'react-router-d
 import { generatePreservedRoutes, generateRegularRoutes } from './core'
 
 type Element = () => JSX.Element
-type Module = { default: Element; Loader: LoaderFunction; Action: ActionFunction; ErrorBoundary: Element }
+type Module = { default: Element; Loader: LoaderFunction; Action: ActionFunction; Error: Element }
 
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[]*.{jsx,tsx}', '!**/(_app|404).*'])
@@ -14,7 +14,7 @@ const preservedRoutes = generatePreservedRoutes<Element>(PRESERVED)
 
 const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(ROUTES, (module, key) => {
   const Element = lazy(module)
-  const ErrorBoundary = lazy(() => module().then((module) => ({ default: module.ErrorBoundary })))
+  const Error = lazy(() => module().then((module) => ({ default: module.Error })))
   const index = /index\.(jsx|tsx)$/.test(key) ? { index: true } : {}
 
   return {
@@ -22,7 +22,7 @@ const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(
     element: <Suspense fallback={null} children={<Element />} />,
     loader: async (...args) => module().then((mod) => mod?.Loader?.(...args)),
     action: async (...args) => module().then((mod) => mod?.Action?.(...args)),
-    errorElement: <Suspense fallback={null} children={<ErrorBoundary />} />,
+    errorElement: <Suspense fallback={null} children={<Error />} />,
   }
 })
 

--- a/src/react-router.tsx
+++ b/src/react-router.tsx
@@ -5,7 +5,7 @@ import type { ActionFunction, RouteObject, LoaderFunction } from 'react-router-d
 import { generatePreservedRoutes, generateRegularRoutes } from './core'
 
 type Element = () => JSX.Element
-type Module = { default: Element; Loader: LoaderFunction; Action: ActionFunction; Error: Element }
+type Module = { default: Element; Loader: LoaderFunction; Action: ActionFunction; ErrorElement: Element }
 
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[]*.{jsx,tsx}', '!**/(_app|404).*'])
@@ -14,7 +14,7 @@ const preservedRoutes = generatePreservedRoutes<Element>(PRESERVED)
 
 const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(ROUTES, (module, key) => {
   const Element = lazy(module)
-  const Error = lazy(() => module().then((module) => ({ default: module.Error })))
+  const ErrorElement = lazy(() => module().then((module) => ({ default: module.ErrorElement })))
   const index = /index\.(jsx|tsx)$/.test(key) ? { index: true } : {}
 
   return {
@@ -22,7 +22,7 @@ const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(
     element: <Suspense fallback={null} children={<Element />} />,
     loader: async (...args) => module().then((mod) => mod?.Loader?.(...args)),
     action: async (...args) => module().then((mod) => mod?.Action?.(...args)),
-    errorElement: <Suspense fallback={null} children={<Error />} />,
+    errorElement: <Suspense fallback={null} children={<ErrorElement />} />,
   }
 })
 

--- a/src/react-router.tsx
+++ b/src/react-router.tsx
@@ -5,7 +5,7 @@ import type { ActionFunction, RouteObject, LoaderFunction } from 'react-router-d
 import { generatePreservedRoutes, generateRegularRoutes } from './core'
 
 type Element = () => JSX.Element
-type Module = { default: Element; Loader: LoaderFunction; Action: ActionFunction }
+type Module = { default: Element; Loader: LoaderFunction; Action: ActionFunction; ErrorBoundary: Element }
 
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[]*.{jsx,tsx}', '!**/(_app|404).*'])
@@ -14,6 +14,7 @@ const preservedRoutes = generatePreservedRoutes<Element>(PRESERVED)
 
 const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(ROUTES, (module, key) => {
   const Element = lazy(module)
+  const ErrorBoundary = lazy(() => module().then((module) => ({ default: module.ErrorBoundary })))
   const index = /index\.(jsx|tsx)$/.test(key) ? { index: true } : {}
 
   return {
@@ -21,6 +22,7 @@ const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(
     element: <Suspense fallback={null} children={<Element />} />,
     loader: async (...args) => module().then((mod) => mod?.Loader?.(...args)),
     action: async (...args) => module().then((mod) => mod?.Action?.(...args)),
+    errorElement: <Suspense fallback={null} children={<ErrorBoundary />} />,
   }
 })
 


### PR DESCRIPTION
Added the errorElement used by react-router as an expor from the path under ErrorBoundery