### PR TITLE
fix: exported module name

### DIFF
--- a/src/react-router.tsx
+++ b/src/react-router.tsx
@@ -5,7 +5,7 @@ import type { ActionFunction, RouteObject, LoaderFunction } from 'react-router-d
 import { generatePreservedRoutes, generateRegularRoutes } from './core'
 
 type Element = () => JSX.Element
-type Module = { default: Element; Loader: LoaderFunction; Action: ActionFunction; ErrorElement: Element }
+type Module = { default: Element; loader: LoaderFunction; action: ActionFunction; ErrorBoundary: Element }
 
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[]*.{jsx,tsx}', '!**/(_app|404).*'])
@@ -14,14 +14,14 @@ const preservedRoutes = generatePreservedRoutes<Element>(PRESERVED)
 
 const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(ROUTES, (module, key) => {
   const Element = lazy(module)
-  const ErrorElement = lazy(() => module().then((module) => ({ default: module.ErrorElement })))
+  const ErrorElement = lazy(() => module().then((module) => ({ default: module.ErrorBoundary })))
   const index = /index\.(jsx|tsx)$/.test(key) ? { index: true } : {}
 
   return {
     ...index,
     element: <Suspense fallback={null} children={<Element />} />,
-    loader: async (...args) => module().then((mod) => mod?.Loader?.(...args)),
-    action: async (...args) => module().then((mod) => mod?.Action?.(...args)),
+    loader: async (...args) => module().then((mod) => mod?.loader?.(...args)),
+    action: async (...args) => module().then((mod) => mod?.action?.(...args)),
     errorElement: <Suspense fallback={null} children={<ErrorElement />} />,
   }
 })


### PR DESCRIPTION
Change the module export name to `loader`, `action`, and `ErrorBoundary` to match with Remix convention.