### PR TITLE
feat: make Routes accept optional ReactLocation #21

### DIFF
--- a/src/react-location.tsx
+++ b/src/react-location.tsx
@@ -24,9 +24,11 @@ const NotFound = preservedRoutes?.['404'] || Fragment
 const location = new ReactLocation()
 const routes = [...regularRoutes, { path: '*', element: <NotFound /> }]
 
-export const Routes = (props: Omit<RouterProps, 'children' | 'location' | 'routes'> = {}) => {
+export const Routes = (
+  props: Omit<RouterProps, 'children' | 'location' | 'routes'> & Partial<Pick<RouterProps, 'location'>> = {}
+) => {
   return (
-    <Router {...props} location={location} routes={routes}>
+    <Router routes={routes} location={location} {...props}>
       <App>
         <Outlet />
       </App>


### PR DESCRIPTION
As a developer, I would like the ability to have Routes accept a different ReactLocation to enable hash or memory paths (ie. /#/my_page as oppose to /my_page).