### PR TITLE
fix: folders and files with the word "index" cannot be accessed #23

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -2,7 +2,7 @@ const patterns = {
   route: [/\/src\/pages\/|\.(jsx|tsx)$/g, ''],
   splat: [/\[\.{3}.+\]/, '*'],
   param: [/\[([^\]]+)\]/g, ':$1'],
-  slash: [/index|\./g, '/'],
+  slash: [/^index|\./g, '/'],
 } as const
 
 type PreservedKey = '_app' | '404'


### PR DESCRIPTION
There is a bug where if you name any folder or file with the word "index" it cannot be accessed (eg. http://localhost:3000/my_index/page) does not work.