### PR TITLE
feat: named index pages (similar to solidjs/nextjs-13 using parenthesis) #25

### DIFF
--- a/src/react-location.tsx
+++ b/src/react-location.tsx
@@ -7,7 +7,7 @@ type Element = () => JSX.Element
 type Module = { default: Element; Loader: LoaderFn; Pending: Element; Failure: Element }
 
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
-const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[]*.{jsx,tsx}', '!**/(_app|404).*'])
+const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[(]*.{jsx,tsx}', '!**/(_app|404).*'])
 
 const preservedRoutes = generatePreservedRoutes<Element>(PRESERVED)
 


### PR DESCRIPTION
SUMMARY

As a developer, I would like to rename index.tsx to something different but still function like an index page. 

SolidJS/NextJS-13 has this functionality where you can name a file and surround it with parenthesis to function like an index page such as  (named_page).tsx.

Also there is a bug where if you name any folder or file with the word "index" it cannot be accessed (eg. http://localhost/my_index/page) does not work.

NOTE:

For repo:https://github.com/oedotme/render.git file:prerender.ts line:16 needs to be changed to

```javascript
const routes = files.map((file: string) =>
  file.replace(/^src\/pages|^index|\([^)]+\)|\.(jsx|tsx)$/g, ''))
```

in order for this fix to not break your other repo.