### PR TITLE
feat: export some type and methods

### DIFF
--- a/src/react-router.tsx
+++ b/src/react-router.tsx
@@ -1,18 +1,18 @@
 import { Fragment, lazy, Suspense } from 'react'
-import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom'
+import { ActionFunctionArgs, createBrowserRouter, LoaderFunctionArgs, Outlet, RouterProvider } from 'react-router-dom'
 import type { ActionFunction, RouteObject, LoaderFunction } from 'react-router-dom'
 
 import { generatePreservedRoutes, generateRegularRoutes } from './core'
 
-type Element = () => JSX.Element
-type Module = { default: Element; Loader: LoaderFunction; Action: ActionFunction; ErrorElement: Element }
+export type Element = () => JSX.Element
+export type Module = { default: Element; Loader: LoaderFunction; Action: ActionFunction; ErrorElement: Element }
 
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[]*.{jsx,tsx}', '!**/(_app|404).*'])
 
 const preservedRoutes = generatePreservedRoutes<Element>(PRESERVED)
 
-const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(ROUTES, (module, key) => {
+export const buildRegularRoute = (module: () => Promise<Module>, key: string) => {
   const Element = lazy(module)
   const ErrorElement = lazy(() => module().then((module) => ({ default: module.ErrorElement || null })))
   const index = /(?<!pages\/)index\.(jsx|tsx)$/.test(key) ? { index: true } : {}
@@ -20,11 +20,13 @@ const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(
   return {
     ...index,
     element: <Suspense fallback={null} children={<Element />} />,
-    loader: (...args) => module().then((mod) => mod?.Loader?.(...args) || null),
-    action: (...args) => module().then((mod) => mod?.Action?.(...args) || null),
+    loader: async (...args: [LoaderFunctionArgs]) => module().then((mod) => mod?.Loader?.(...args) || null),
+    action: async (...args: [ActionFunctionArgs]) => module().then((mod) => mod?.Action?.(...args) || null),
     errorElement: <Suspense fallback={null} children={<ErrorElement />} />,
   }
-})
+}
+
+const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(ROUTES, buildRegularRoute)
 
 const App = preservedRoutes?.['_app'] || Fragment
 const NotFound = preservedRoutes?.['404'] || Fragment

--- a/src/solid-router.tsx
+++ b/src/solid-router.tsx
@@ -4,7 +4,7 @@ import { RouteDataFunc, RouteDataFuncArgs, RouteDefinition, Router, useRoutes } 
 
 import { generatePreservedRoutes, generateRegularRoutes } from './core'
 
-type Module = { default: Component; Loader: RouteDataFunc }
+export type Module = { default: Component; Loader: RouteDataFunc }
 type Route = { path?: string; component?: Component; children?: Route[] }
 
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
@@ -12,10 +12,12 @@ const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[]*.{jsx,tsx}', '!**
 
 const preservedRoutes = generatePreservedRoutes<Component>(PRESERVED)
 
-const regularRoutes = generateRegularRoutes<Route, () => Promise<Module>>(ROUTES, (module) => ({
+export const buildRegularRoute = (module: () => Promise<Module>) => ({
   component: lazy(module),
-  data: (args: RouteDataFuncArgs) => module().then((mod) => mod?.Loader?.(args) || null),
-}))
+  data: async (args: RouteDataFuncArgs) => module().then((mod) => mod?.Loader?.(args) || null),
+})
+
+const regularRoutes = generateRegularRoutes<Route, () => Promise<Module>>(ROUTES, buildRegularRoute)
 
 const Fragment = (props: ParentProps) => <>{props.children}</>
 const App = preservedRoutes?.['_app'] || Fragment


### PR DESCRIPTION
## Description

Add `core` in the exports entry of `package.json` in order to use both methods `generatePreservedRoutes` and `generateRegularRoutes`.

## Use case

As the Vite's glob import API patterns are resolved relative to project root, if you specify a custom root vite config, generouted won't work as it should. Given this vite config file:
```js
// vite.congig.js
import { defineConfig } from 'vite'
import react from '@vitejs/plugin-react'

export default defineConfig({ 
  plugins: [react()],
  root: resolve(process.cwd(), 'src'),
})
```
and this app structure:
```
my-app
├── package.json
├── src
│   ├── index.html
│   ├── index.tsx
│   ├── pages
│   │   ├── 404.tsx
│   │   ├── _app.tsx
│   │   ├── index.tsx
│   └── public
│       └── translations
├── tsconfig.json
└── vite.config.mjs
```
Then if you import the `Routes` from `generouted/react-router`, you won't have any route generated (expect a default app route and a default 404 route) as the folder used by the glob pattern in https://github.com/oedotme/generouted/blob/e6eb81a03ff2d5bff6e18ffdefab12ed7dbce516/src/react-router.tsx#L10...L11 does not exists.

The solution proposed here is to exports methods from `core` and being able to build routes from other glob pattern. Like this:
```js
import React from 'react';
import { Outlet, RouterProvider, createHashRouter } from 'react-router-dom';
import { generatePreservedRoutes, generateRegularRoutes } from 'generouted/core';
import { buildRegularRoute } from 'generouted/react-router';
import type { Module as ReactRouterDomModule } from 'generouted/react-router';

function generateRouter(app: React.FunctionComponent) {
  const AppComponent = app;

  const appRoutes = generateRegularRoutes(
    import.meta.glob<ReactRouterDomModule>([
      '/pages/**/[\\w[]*.{jsx,tsx}',
      '!**/(_app|404).*',
    ]),
    buildRegularRoute,
    [/\/pages\/|\.(jsx|tsx)$/g, ''],
  );
  const routes = [
    { element: <AppComponent children={(
      <>
        <Outlet />
      </>
    )} />, children: [...appRoutes]},
  ];

  const router = createHashRouter(routes);
  return () => <RouterProvider router={router} />;
}
```