### PR TITLE
Fix/optional loaders and default error component

### DIFF
--- a/src/react-router.tsx
+++ b/src/react-router.tsx
@@ -1,5 +1,5 @@
 import { Fragment, lazy, Suspense } from 'react'
-import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter, Outlet, RouterProvider, useRouteError } from 'react-router-dom'
 import type { ActionFunction, RouteObject, LoaderFunction } from 'react-router-dom'
 
 import { generatePreservedRoutes, generateRegularRoutes } from './core'
@@ -12,9 +12,13 @@ const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[]*.{jsx,tsx}', '!**
 
 const preservedRoutes = generatePreservedRoutes<Element>(PRESERVED)
 
+export function DefaultErrorElement() {
+  throw new Error(`Generouted: Internal Error: ${useRouteError()}`)
+}
+
 const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(ROUTES, (module, key) => {
   const Element = lazy(module)
-  const ErrorElement = lazy(() => module().then((module) => ({ default: module.ErrorElement })))
+  const ErrorElement = lazy(() => module().then((module) => ({ default: module.ErrorElement || DefaultErrorElement })))
   const index = /index\.(jsx|tsx)$/.test(key) ? { index: true } : {}
 
   return {

--- a/src/react-router.tsx
+++ b/src/react-router.tsx
@@ -20,8 +20,8 @@ const regularRoutes = generateRegularRoutes<RouteObject, () => Promise<Module>>(
   return {
     ...index,
     element: <Suspense fallback={null} children={<Element />} />,
-    loader: async (...args) => module().then((mod) => mod?.Loader?.(...args)),
-    action: async (...args) => module().then((mod) => mod?.Action?.(...args)),
+    loader: async (...args) => module().then((mod) => mod?.Loader?.(...args) || null),
+    action: async (...args) => module().then((mod) => mod?.Action?.(...args) || null),
     errorElement: <Suspense fallback={null} children={<ErrorElement />} />,
   }
 })

--- a/src/react-router.tsx
+++ b/src/react-router.tsx
@@ -7,6 +7,7 @@ import { generatePreservedRoutes, generateRegularRoutes } from './core'
 type Element = () => JSX.Element
 type Module = { default: Element; Loader: LoaderFunction; Action: ActionFunction; ErrorElement: Element }
 
+// https://vitejs.dev/guide/features.html#glob-import
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[]*.{jsx,tsx}', '!**/(_app|404).*'])
 


### PR DESCRIPTION
Thanks for the wonderful package. We enjoy using it in our application.

We got some issues regarding the changes in v1.6.1 to offer support for error elements in React Router. 

```
Uncaught Error: Element type is invalid. Received a promise that resolves to: undefined. Lazy element type must resolve to a class or function.
```

Also, the dynamic loader is not working correctly for us when not used/defined:

```
Error: You defined a loader for route "0-0-0" but didn't return anything from your `loader` function. Please return a value or `null`.
```

This PR fixes both issues for us.