### PR TITLE
Fix solid-router integration.

### DIFF
--- a/packages/generouted/src/solid-router.tsx
+++ b/packages/generouted/src/solid-router.tsx
@@ -21,7 +21,7 @@ const Fragment = (props: ParentProps) => <>{props.children}</>
 const App = preservedRoutes?.['_app'] || Fragment
 const NotFound = preservedRoutes?.['404'] || Fragment
 
-export const routes = [...regularRoutes, { path: '*', component: <NotFound /> }] as RouteDefinition[]
+export const routes = [...regularRoutes, { path: '*', component: NotFound }] as RouteDefinition[]
 
 export const Routes = () => {
   const Routes = useRoutes(routes)


### PR DESCRIPTION
`NotFound` page component should be a function and not rendered.

If the `NotFound` function is called but it uses any router features (like returning a `<Navigate href="/" />`), the whole app will crash. `component` expects a function not a JSX expression.