### PR TITLE
fix: support export async function

### DIFF
--- a/shared/core/src/index.ts
+++ b/shared/core/src/index.ts
@@ -12,9 +12,9 @@ const getRouteId = (path: string) => path.replace(...patterns.route).replace(/\W
 
 const getRouteExports = (content: string) => ({
   default: /^export\s+default\s/gm.test(content),
-  loader: /^export\s+(const|function|let)\s+Loader\W/gm.test(content),
-  action: /^export\s+(const|function|let)\s+Action\W/gm.test(content),
-  pending: /^export\s+(const|function|let)\s+Pending\W/gm.test(content),
+  loader: /^export\s+(const|function|async function|let)\s+Loader\W/gm.test(content),
+  action: /^export\s+(const|function|async function|let)\s+Action\W/gm.test(content),
+  pending: /^export\s+(const|function|async function|let)\s+Pending\W/gm.test(content),
   catch_: /^export\s+(const|function|let)\s+Catch\W/gm.test(content),
 })
 


### PR DESCRIPTION
Hey, really like this plugin.

We noticed that actions and loaders declared as async functions are not being correctly exported by the routes generator.

Looked into the code and seems like it was because the regex is not matching for `async function`. 

Not sure if there is a reason for this, but created a small PR to support it.

Let me know if there is anything else that needs to be done to solve this. 