### PR TITLE
feat: type-safe router-state-based global modals

### DIFF
--- a/examples/react-router/plugin/src/pages/+modal.tsx
+++ b/examples/react-router/plugin/src/pages/+modal.tsx
@@ -1,0 +1,25 @@
+import { useLocation } from 'react-router-dom'
+
+import { useModals } from '@/routes.gen'
+
+export default function Welcome() {
+  const location = useLocation()
+  const modals = useModals()
+
+  const handleClose = () => modals.close()
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.25)', display: 'grid', placeContent: 'center' }}
+    >
+      <div style={{ position: 'absolute', inset: 0, zIndex: -1 }} onClick={handleClose} />
+      <div style={{ background: 'white', padding: 40, height: 300, width: 600 }}>
+        <h2>Global Modal!</h2>
+        <p>Current pathname: {location.pathname}</p>
+
+        <button onClick={() => modals.close()}>Close</button>
+        <button onClick={() => modals.close({ at: '/login' })}>Close and redirect to /login</button>
+      </div>
+    </div>
+  )
+}

--- a/examples/react-router/plugin/src/pages/_app.tsx
+++ b/examples/react-router/plugin/src/pages/_app.tsx
@@ -1,9 +1,10 @@
 import { Outlet } from 'react-router-dom'
 
-import { Link, useNavigate, useParams } from '../routes.gen'
+import { Link, Modals, useModals, useNavigate, useParams } from '../routes.gen'
 
 export default function App() {
   const navigate = useNavigate()
+  const modals = useModals()
   const { id, pid } = useParams('/posts/:id/:pid?')
 
   const a = () => navigate('/posts/:id', { params: { id: 'a' } })
@@ -24,12 +25,16 @@ export default function App() {
         <Link to="/posts/:id" params={{ id: 'id' }}>
           Posts by id
         </Link>
+        <button onClick={() => modals.open('/modal')}>Global modal at current route</button>
+        <button onClick={() => modals.open('/modal', { at: '/about' })}>Global modal at /about</button>
         <button onClick={e}>navigate to</button>
       </header>
 
       <main>
         <Outlet />
       </main>
+
+      <Modals />
     </section>
   )
 }

--- a/examples/react-router/plugin/src/routes.gen.tsx
+++ b/examples/react-router/plugin/src/routes.gen.tsx
@@ -3,7 +3,7 @@
 
 import { Fragment, lazy, Suspense } from 'react'
 import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom'
-import { components, hooks, utils } from '@generouted/react-router/client'
+import { components, hooks, modals, utils } from '@generouted/react-router/client'
 
 import app from './pages/_app'
 import noMatch from './pages/404'
@@ -82,8 +82,13 @@ type Params = {
   '/posts/:id/:pid?': { id: string; pid?: string }
 }
 
+type ModalPath = `/modal`
+
 export const routes = [{ element: <App />, children: [...config, { path: '*', element: <NoMatch /> }] }]
 export const Routes = () => <RouterProvider router={createBrowserRouter(routes)} />
+
+export { Modals } from '@generouted/react-router/client'
 export const { Link, Navigate } = components<Path, Params>()
 export const { useNavigate, useParams } = hooks<Path, Params>()
+export const { useModals } = modals<ModalPath, Path, Params>()
 export const { rediect } = utils<Path, Params>()

--- a/plugins/react-router/readme.md
+++ b/plugins/react-router/readme.md
@@ -115,6 +115,64 @@ export default function Home() {
 }
 ```
 
+### Type-safe global modals
+
+Although all modals are global, it's nice to co-locate modals with relevant routes.
+
+Create modal routes by prefixing a valid route file name with a plus sign `+`. Why `+`? You can think of it as an extra route, as the modal overlays the current route:
+
+```tsx
+// src/pages/+login.tsx
+
+import { Modal } from '@/ui'
+
+export default function Login() {
+  return <Modal>Content</Modal>
+}
+```
+
+Then render the `<Modals>` component in `src/pages/_app.tsx`, this component renders the current/opened modal component. To navigate to a modal use `useModals` hook exported from `routes.gen.tsx`:
+
+```tsx
+// src/pages/_app.tsx
+
+import { Outlet } from 'react-router-dom'
+
+import { Modals, useModals } from '../routes.gen'
+
+export default function App() {
+  const modals = useModals()
+
+  return (
+    <section>
+      <header>
+        <nav>...</nav>
+        <button onClick={() => modals.open('/login')}>Open modal</button>
+      </header>
+
+      <main>
+        <Outlet />
+      </main>
+
+      <Modals />
+    </section>
+  )
+}
+```
+
+With `useModals` you can use `modals.open('/modal-path')` and `modals.close()`, and by default it opens/closes the modal on the current active route.
+
+Both methods come with React Router's `navigate()` options with one prop added `at`, for optionally navigating to a route while opening/closing a modal, and it's also type-safe!
+
+- `modals.open(path, options)`
+- `modals.close(options)`
+
+`at` should be also a valid route path, here are some usage examples:
+
+- `modals.open('/login', { at: '/auth', replace: true })`
+- `modals.open('/info', { at: '/invoice/:id', { params: { id: 'xyz' } } })`
+- `modals.close({ at: '/', replace: false })`
+
 ## Examples
 
 ### React Router

--- a/plugins/react-router/src/client/index.ts
+++ b/plugins/react-router/src/client/index.ts
@@ -1,3 +1,4 @@
 export * from './components'
 export * from './hooks'
+export * from './modals'
 export * from './utils'

--- a/plugins/react-router/src/client/modals.tsx
+++ b/plugins/react-router/src/client/modals.tsx
@@ -1,0 +1,43 @@
+import React, { Fragment } from 'react'
+import { NavigateOptions, useLocation, useNavigate } from 'react-router-dom'
+
+const MODALS = import.meta.glob<{ default: () => JSX.Element }>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
+const modalRoutes = Object.keys(MODALS).reduce<Record<string, () => JSX.Element>>((modals, modal) => {
+  const path = modal
+    .replace(/^\.?\/src\/pages\/|^\/pages\/|\.(jsx|tsx)$/g, '')
+    .replace(/\+/g, '')
+    .replace(/(\/)?index/g, '')
+    .replace(/\./g, '/')
+
+  return { ...modals, [`/${path}`]: MODALS[modal].default }
+}, {})
+
+export const modals = <ModalPath extends string, Path extends string, Params extends Record<string, any>>() => {
+  type ParamPath = keyof Params
+  type Options<P> = NavigateOptions & (P extends ParamPath ? { at: P; params: Params[P] } : { at: P; params?: never })
+
+  return {
+    useModals: () => {
+      const location = useLocation()
+      const navigate = useNavigate()
+
+      return {
+        current: location.state?.modal || '',
+        open: <P extends Path>(path: ModalPath, options?: Options<P>) => {
+          const { at, state, ...opts } = options || {}
+          navigate(at || location.pathname, { ...opts, state: { ...location.state, ...state, modal: path } })
+        },
+        close: <P extends Path>(options?: Options<P>) => {
+          const { at, state, ...opts } = options || {}
+          navigate(at || location.pathname, { ...opts, state: { ...location.state, ...state, modal: '' } })
+        },
+      }
+    },
+  }
+}
+
+export const Modals = () => {
+  const { current } = modals().useModals()
+  const Modal = modalRoutes[current] || Fragment
+  return <Modal />
+}

--- a/plugins/react-router/src/generate.ts
+++ b/plugins/react-router/src/generate.ts
@@ -12,6 +12,7 @@ const capitalize = (id: string) => id.replace(/\b[\w]/, (character) => character
 const generateRoutes = async () => {
   const source = ['./src/pages/**/[\\w[-]*.{jsx,tsx}']
   const files = await fg(source, { onlyFiles: true })
+  const modal = await fg('./src/pages/**/[+]*.{jsx,tsx}', { onlyFiles: true })
 
   const imports: string[] = []
   const modules: string[] = []
@@ -83,10 +84,21 @@ const generateRoutes = async () => {
     return value
   }).replace(/"#_|_#"/g, '')
 
+  const modals = modal.map(
+    (path) =>
+      `/${path
+        .replace(...patterns.route)
+        .replace(/\+/g, '')
+        .replace(/(\/)?index/g, '')
+        .replace(/\./g, '/')}`
+  )
+
   const types =
     `type Path = "${[...new Set(paths)].sort().join('" | "')}"`.replace(/"/g, '`') +
     '\n\n' +
-    `type Params = { ${params.join('; ')} }`
+    `type Params = { ${params.join('; ')} }` +
+    '\n\n' +
+    `type ModalPath = "${modals.sort().join('" | "') || 'never'}"`.replace(/"/g, modals.length ? '`' : '')
 
   const content = template
     .replace('// imports', imports.join('\n'))

--- a/plugins/react-router/src/template.ts
+++ b/plugins/react-router/src/template.ts
@@ -3,7 +3,7 @@ export const template = `// Generouted, changes to this file will be overriden
 
 import { Fragment, lazy, Suspense } from 'react'
 import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom'
-import { components, hooks, utils } from '@generouted/react-router/client'
+import { components, hooks, modals, utils } from '@generouted/react-router/client'
 
 // imports
 
@@ -15,7 +15,10 @@ const config = // config
 
 export const routes = [{ element: <App />, children: [...config, { path: '*', element: <NoMatch /> }] }]
 export const Routes = () => <RouterProvider router={createBrowserRouter(routes)} />
+
+export { Modals } from '@generouted/react-router/client'
 export const { Link, Navigate } = components<Path, Params>()
 export const { useNavigate, useParams } = hooks<Path, Params>()
+export const { useModals } = modals<ModalPath, Path, Params>()
 export const { rediect } = utils<Path, Params>()
 `

--- a/plugins/react-router/tsconfig.json
+++ b/plugins/react-router/tsconfig.json
@@ -14,7 +14,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "types": ["vite/client"]
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
### Changes
This PR adds type-safe file-based global modals for React Router that works with the current `generouted` conventions

You can create a modal by prefixing a route file-name with `+` within `src/pages/**`, think of it as an extra route -- as the modal overlays the current route: `src/pages/+login.tsx` or `src/pages/checkout/+step-1.tsx`

### Featues
- Type-safe modal opening with the current type-safe navigation
- Makes it super easy for multi-step modals navigation
- Persistent modal opening on refresh
- Works with back/forward actions, can be avoided with `{ replace: true }`

### Components

- `<Modals>` component needs to be rendered in `src/pages/_app.tsx`, this component renders the current/opened modal component

- `useModals` can be used to navigate to a modal and it's exported from `routes.gen.tsx`. The hook returns two methods, `modals.open(path, options?)` and `modals.close(options?)`

`options` is the same React Router `useNavigate > navigate` `options`, with an optional `at` prop added to navigate to another route (that's also type-safe!) while opening/closing a modal.

The readme contains the setup and usage examples.