### PR TITLE
feat: solid type-safe router-state-based global modals

### DIFF
--- a/examples/solid-router/src/pages/+modal.tsx
+++ b/examples/solid-router/src/pages/+modal.tsx
@@ -1,0 +1,31 @@
+import { useLocation } from '@solidjs/router'
+
+import { useModals } from '@/router'
+
+export default function Welcome() {
+  const location = useLocation()
+  const modals = useModals()
+
+  const handleClose = () => modals.close()
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.25)',
+        display: 'grid',
+        'place-content': 'center',
+      }}
+    >
+      <div style={{ position: 'absolute', inset: 0, 'z-index': -1 }} onClick={handleClose} />
+      <div style={{ background: 'white', padding: '40px', height: '300px', width: '600px' }}>
+        <h2>Global Modal!</h2>
+        <p>Current pathname: {location.pathname}</p>
+
+        <button onClick={() => modals.close()}>Close</button>
+        <button onClick={() => modals.close({ at: '/about' })}>Close and redirect to /about</button>
+      </div>
+    </div>
+  )
+}

--- a/examples/solid-router/src/pages/_app.tsx
+++ b/examples/solid-router/src/pages/_app.tsx
@@ -1,9 +1,10 @@
 import { ParentProps } from 'solid-js'
 
-import { A, useNavigate } from '../router'
+import { A, useModals, useNavigate } from '@/router'
 
 export default function App(props: ParentProps) {
   const navigate = useNavigate()
+  const modals = useModals()
 
   const a = () => navigate('/about')
   const b = () => navigate('/posts/:id/:pid?', { params: { id: 'xyz' } })
@@ -16,6 +17,7 @@ export default function App(props: ParentProps) {
         <A href="/posts/:id" params={{ id: 'xyz' }}>
           Post by Id
         </A>
+        <button onClick={() => modals.open('/modal', { at: '/posts' })}>Open global modal</button>
       </header>
 
       <main>{props.children}</main>

--- a/examples/solid-router/src/router.ts
+++ b/examples/solid-router/src/router.ts
@@ -12,7 +12,7 @@ type Params = {
   '/posts/:id/deep': { id: string }
 }
 
-type ModalPath = never
+type ModalPath = `/modal`
 
 export const { A, Navigate } = components<Path, Params>()
 export const { useMatch, useModals, useNavigate, useParams } = hooks<Path, Params, ModalPath>()

--- a/packages/generouted/src/solid-router-lazy.tsx
+++ b/packages/generouted/src/solid-router-lazy.tsx
@@ -1,25 +1,28 @@
 /** @jsxImportSource solid-js */
-import { Component, lazy, ParentProps } from 'solid-js'
-import { RouteDataFunc, RouteDataFuncArgs, RouteDefinition, Router, useRoutes } from '@solidjs/router'
+import { Component, createMemo, lazy, ParentProps } from 'solid-js'
+import { RouteDataFunc, RouteDataFuncArgs, RouteDefinition, Router, useLocation, useRoutes } from '@solidjs/router'
 
-import { generatePreservedRoutes, generateRegularRoutes } from './core'
+import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } from './core'
 
 type Module = { default: Component; Loader: RouteDataFunc }
 type Route = { path?: string; component?: Component; children?: Route[] }
 
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
+const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[-]*.{jsx,tsx}', '!**/(_app|404).*'])
 
 const preservedRoutes = generatePreservedRoutes<Component>(PRESERVED)
+const modalRoutes = generateModalRoutes<Element>(MODALS)
 
 const regularRoutes = generateRegularRoutes<Route, () => Promise<Module>>(ROUTES, (module) => ({
   component: lazy(module),
   data: (args: RouteDataFuncArgs) => module().then((mod) => mod?.Loader?.(args) || null),
 }))
 
-const Fragment = (props: ParentProps) => props.children
+const Fragment = (props: ParentProps) => props?.children
 const App = preservedRoutes?.['_app'] || Fragment
 const NotFound = preservedRoutes?.['404'] || Fragment
+const Modals = () => createMemo(() => modalRoutes[useLocation<{ modal: string }>().state?.modal || ''] || Fragment)
 
 export const routes = [...regularRoutes, { path: '*', component: NotFound }] as RouteDefinition[]
 
@@ -30,6 +33,7 @@ export const Routes = () => {
     <Router>
       <App>
         <Routes />
+        <Modals />
       </App>
     </Router>
   )

--- a/packages/generouted/src/solid-router.tsx
+++ b/packages/generouted/src/solid-router.tsx
@@ -1,25 +1,28 @@
 /** @jsxImportSource solid-js */
-import { Component, ParentProps } from 'solid-js'
-import { RouteDataFunc, RouteDefinition, Router, useRoutes } from '@solidjs/router'
+import { Component, createMemo, ParentProps } from 'solid-js'
+import { RouteDataFunc, RouteDefinition, Router, useLocation, useRoutes } from '@solidjs/router'
 
-import { generatePreservedRoutes, generateRegularRoutes } from './core'
+import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } from './core'
 
 type Module = { default: Component; Loader: RouteDataFunc }
 type RouteDef = { path?: string; component?: Component; children?: RouteDef[] }
 
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
+const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(['/src/pages/**/[\\w[-]*.{jsx,tsx}', '!**/(_app|404).*'], { eager: true })
 
 const preservedRoutes = generatePreservedRoutes<Component>(PRESERVED)
+const modalRoutes = generateModalRoutes<Element>(MODALS)
 
 const regularRoutes = generateRegularRoutes<RouteDef, Module>(ROUTES, (module) => ({
   component: module?.default || Fragment,
   data: module?.Loader || null,
 }))
 
-const Fragment = (props: ParentProps) => props.children
+const Fragment = (props: ParentProps) => props?.children
 const App = preservedRoutes?.['_app'] || Fragment
 const NotFound = preservedRoutes?.['404'] || Fragment
+const Modals = () => createMemo(() => modalRoutes[useLocation<{ modal: string }>().state?.modal || ''] || Fragment)
 
 export const routes = [...regularRoutes, { path: '*', component: NotFound }] as RouteDefinition[]
 
@@ -30,6 +33,7 @@ export const Routes = () => {
     <Router>
       <App>
         <Routes />
+        <Modals />
       </App>
     </Router>
   )

--- a/plugins/react-router/readme.md
+++ b/plugins/react-router/readme.md
@@ -136,7 +136,7 @@ Then render the `<Modals>` component in `src/pages/_app.tsx`, this component ren
 import { Outlet } from 'react-router-dom'
 import { Modals } from 'generouted/react-router'
 
-import { useModals } from '../routes.gen'
+import { useModals } from '../router'
 
 export default function App() {
   const modals = useModals()

--- a/plugins/solid-router/readme.md
+++ b/plugins/solid-router/readme.md
@@ -152,7 +152,7 @@ export default function App(props: ParentProps) {
 
 With `useModals` you can use `modals.open('/modal-path')` and `modals.close()`, and by default it opens/closes the modal on the current active route.
 
-Both methods come with React Router's `navigate()` options with one prop added `at`, for optionally navigating to a route while opening/closing a modal, and it's also type-safe!
+Both methods come with Solid Router's `navigate()` options with one prop added `at`, for optionally navigating to a route while opening/closing a modal, and it's also type-safe!
 
 - `modals.open(path, options)`
 - `modals.close(options)`

--- a/plugins/solid-router/readme.md
+++ b/plugins/solid-router/readme.md
@@ -109,6 +109,60 @@ export default function Home() {
 }
 ```
 
+### Type-safe global modals
+
+Although all modals are global, it's nice to co-locate modals with relevant routes.
+
+Create modal routes by prefixing a valid route file name with a plus sign `+`. Why `+`? You can think of it as an extra route, as the modal overlays the current route:
+
+```tsx
+// src/pages/+login.tsx
+
+import { Modal } from '@/ui'
+
+export default function Login() {
+  return <Modal>Content</Modal>
+}
+```
+
+To navigate to a modal use `useModals` hook exported from `src/router.ts`:
+
+```tsx
+// src/pages/_app.tsx
+
+import { ParentProps } from 'solid-js'
+
+import { useModals } from '../router'
+
+export default function App(props: ParentProps) {
+  const modals = useModals()
+
+  return (
+    <section>
+      <header>
+        <nav>...</nav>
+        <button onClick={() => modals.open('/login')}>Open modal</button>
+      </header>
+
+      <main>{props.children}</main>
+    </section>
+  )
+}
+```
+
+With `useModals` you can use `modals.open('/modal-path')` and `modals.close()`, and by default it opens/closes the modal on the current active route.
+
+Both methods come with React Router's `navigate()` options with one prop added `at`, for optionally navigating to a route while opening/closing a modal, and it's also type-safe!
+
+- `modals.open(path, options)`
+- `modals.close(options)`
+
+`at` should be also a valid route path, here are some usage examples:
+
+- `modals.open('/login', { at: '/auth', replace: true })`
+- `modals.open('/info', { at: '/invoice/:id', { params: { id: 'xyz' } } })`
+- `modals.close({ at: '/', replace: false })`
+
 ## Examples
 
 - [Plugin](../../examples/solid-router)

--- a/plugins/solid-router/src/client/hooks.ts
+++ b/plugins/solid-router/src/client/hooks.ts
@@ -24,7 +24,7 @@ export const hooks = <Path extends string, Params extends Record<string, any>, M
       const location = useLocation<{ modal: string }>()
       const navigate = useNavigate()
 
-      type Options<P> = NavigateOptions<{ modal: string }> &
+      type Options<P> = Partial<NavigateOptions<{ modal: string }>> &
         (P extends ParamPath ? { at: P; params: Params[P] } : { at: P; params?: never })
 
       return {


### PR DESCRIPTION
### Changes
This PR adds type-safe file-based global modals for Solid Router that works with the current `generouted` conventions

You can create a modal by prefixing a route file-name with `+` within `src/pages/**`, think of it as an extra route -- as the modal overlays the current route: `src/pages/+login.tsx` or `src/pages/checkout/+step-1.tsx`

### Featues
- Type-safe modal opening with the current type-safe navigation
- Makes it super easy for multi-step modals navigation
- Persistent modal opening on refresh
- Works with back/forward actions, can be avoided with `{ replace: true }`

### Components

- `useModals` can be used to navigate to a modal and it's exported from `routes.gen.tsx`. The hook returns two methods, `modals.open(path, options?)` and `modals.close(options?)`

`options` is the same Solid Router `useNavigate > navigate` `options`, with an optional `at` prop added to navigate to another route (that's also type-safe!) while opening/closing a modal.

Check out [the plugin readme](https://github.com/oedotme/generouted/tree/main/plugins/solid-router) for getting started and usage examples.