### PR TITLE
fix: add missing path in pathless group for solid

### DIFF
--- a/examples/solid-router/src/main.tsx
+++ b/examples/solid-router/src/main.tsx
@@ -1,4 +1,4 @@
 import { render } from 'solid-js/web'
-import { Routes } from '@generouted/solid-router'
-
+import { Routes, routes } from '@generouted/solid-router'
+console.debug(routes)
 render(Routes, document.getElementById('app') as HTMLElement)

--- a/examples/solid-router/src/pages/(app)/(sub)/amazing.tsx
+++ b/examples/solid-router/src/pages/(app)/(sub)/amazing.tsx
@@ -1,0 +1,3 @@
+export default function Amazing() {
+  return <h2>Amazing</h2>
+}

--- a/examples/solid-router/src/pages/(app)/_layout.tsx
+++ b/examples/solid-router/src/pages/(app)/_layout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from '@solidjs/router'
+
+export default function AppLayout() {
+  return (
+    <>
+      <h3>App Layout</h3>
+      <Outlet />
+    </>
+  )
+}

--- a/examples/solid-router/src/pages/(app)/wow.tsx
+++ b/examples/solid-router/src/pages/(app)/wow.tsx
@@ -1,0 +1,4 @@
+export default function Wow() {
+    return <h1>Bow Wow</h1>
+  }
+  

--- a/examples/solid-router/src/pages/_app.tsx
+++ b/examples/solid-router/src/pages/_app.tsx
@@ -17,7 +17,9 @@ export default function App(props: ParentProps) {
         <A href="/posts/:id" params={{ id: 'xyz' }}>
           Post by Id
         </A>
+        <A href="/some/result">Some Result</A>
         <A href="/wow">Wow</A>
+        <A href="/amazing">Amazing</A>
         <button onClick={() => modals.open('/modal', { at: '/posts' })}>Open global modal</button>
       </header>
 

--- a/examples/solid-router/src/pages/_app.tsx
+++ b/examples/solid-router/src/pages/_app.tsx
@@ -17,6 +17,7 @@ export default function App(props: ParentProps) {
         <A href="/posts/:id" params={{ id: 'xyz' }}>
           Post by Id
         </A>
+        <A href="/wow">Wow</A>
         <button onClick={() => modals.open('/modal', { at: '/posts' })}>Open global modal</button>
       </header>
 

--- a/examples/solid-router/src/pages/some/(dummy)/result.tsx
+++ b/examples/solid-router/src/pages/some/(dummy)/result.tsx
@@ -1,0 +1,3 @@
+export default function SomeResult() {
+  return <h1>Some result</h1>
+}

--- a/examples/solid-router/src/router.ts
+++ b/examples/solid-router/src/router.ts
@@ -3,7 +3,17 @@
 
 import { components, hooks } from '@generouted/solid-router/client'
 
-export type Path = `/` | `/:lang?/lang` | `/about` | `/posts` | `/posts/:id` | `/posts/:id/:pid?` | `/posts/:id/deep`
+export type Path =
+  | `/`
+  | `/:lang?/lang`
+  | `/about`
+  | `/amazing`
+  | `/posts`
+  | `/posts/:id`
+  | `/posts/:id/:pid?`
+  | `/posts/:id/deep`
+  | `/some/result`
+  | `/wow`
 
 export type Params = {
   '/:lang?/lang': { lang?: string }

--- a/packages/generouted/src/core.ts
+++ b/packages/generouted/src/core.ts
@@ -84,3 +84,10 @@ export const generateModalRoutes = <T>(files: Record<string, T | any>): Record<s
     return { ...modals, [`/${path}`]: files[key]?.default }
   }, {})
 }
+
+export const generatePathForGroup = <T extends BaseRoute>(route: T, base = '/') => {
+  if (route.id?.startsWith('(') && route.id?.endsWith(')')) {
+    route.path || (route.path = base)
+  }
+  if (route.children) route.children.forEach((sub) => generatePathForGroup(sub, base))
+}

--- a/packages/generouted/src/solid-router-lazy.tsx
+++ b/packages/generouted/src/solid-router-lazy.tsx
@@ -2,7 +2,7 @@
 import { Component, createMemo, lazy, ParentProps } from 'solid-js'
 import { RouteDataFunc, RouteDataFuncArgs, RouteDefinition, Router, useLocation, useRoutes } from '@solidjs/router'
 
-import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } from './core'
+import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes, generatePathForGroup } from './core'
 
 type Module = { default: Component; Loader: RouteDataFunc }
 type Route = { path?: string; component?: Component; children?: Route[] }
@@ -18,6 +18,7 @@ const regularRoutes = generateRegularRoutes<Route, () => Promise<Module>>(ROUTES
   component: lazy(module),
   data: (args: RouteDataFuncArgs) => module().then((mod) => mod?.Loader?.(args) || null),
 }))
+regularRoutes.forEach((route) => generatePathForGroup(route))
 
 const Fragment = (props: ParentProps) => props?.children
 const App = preservedRoutes?.['_app'] || Fragment

--- a/packages/generouted/src/solid-router.tsx
+++ b/packages/generouted/src/solid-router.tsx
@@ -2,10 +2,10 @@
 import { Component, createMemo, ParentProps } from 'solid-js'
 import { RouteDataFunc, RouteDefinition, Router, useLocation, useRoutes } from '@solidjs/router'
 
-import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } from './core'
+import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes, generatePathForGroup } from './core'
 
 type Module = { default: Component; Loader: RouteDataFunc }
-type RouteDef = { path?: string; component?: Component; children?: RouteDef[] }
+type RouteDef = { path?: string; component?: Component; children?: RouteDef[]; id?: string }
 
 const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
@@ -18,6 +18,7 @@ const regularRoutes = generateRegularRoutes<RouteDef, Module>(ROUTES, (module) =
   component: module?.default || Fragment,
   data: module?.Loader || null,
 }))
+regularRoutes.forEach((route) => generatePathForGroup(route))
 
 const Fragment = (props: ParentProps) => props?.children
 const App = preservedRoutes?.['_app'] || Fragment


### PR DESCRIPTION
I Added core function to fix missing path in pathless group routes.
solid-router's `path` is mandatory but path dosen't exist when directory is wrapped with `()`.
related issue is #83.