### PR TITLE
feat: update Tanstack Router generator and examples with latest changes

### DIFF
--- a/examples/tanstack-react-router/package.json
+++ b/examples/tanstack-react-router/package.json
@@ -13,7 +13,7 @@
     "@generouted/tanstack-react-router": "^1.15.0",
     "@tanstack/react-actions": "^0.0.1-beta.64",
     "@tanstack/react-loaders": "^0.0.1-beta.73",
-    "@tanstack/react-router": "^0.0.1-beta.74",
+    "@tanstack/router": "^0.0.1-beta.89",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/tanstack-react-router/src/pages/(auth)/_layout.tsx
+++ b/examples/tanstack-react-router/src/pages/(auth)/_layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from '@tanstack/react-router'
+import { Outlet } from '@tanstack/router'
 
 export default function Layout() {
   return (

--- a/examples/tanstack-react-router/src/pages/_app.tsx
+++ b/examples/tanstack-react-router/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet } from '@tanstack/react-router'
+import { Link, Outlet } from '@tanstack/router'
 
 export default function App() {
   return (

--- a/examples/tanstack-react-router/src/pages/posts/[id].tsx
+++ b/examples/tanstack-react-router/src/pages/posts/[id].tsx
@@ -1,4 +1,4 @@
-import { useMatch } from '@tanstack/react-router'
+import { useMatch } from '@tanstack/router'
 
 export default function Id() {
   const { params } = useMatch({ from: '/posts/$id' })

--- a/examples/tanstack-react-router/src/pages/posts/_layout.tsx
+++ b/examples/tanstack-react-router/src/pages/posts/_layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from '@tanstack/react-router'
+import { Outlet } from '@tanstack/router'
 
 export default function About() {
   return (

--- a/examples/tanstack-react-router/src/routes.gen.tsx
+++ b/examples/tanstack-react-router/src/routes.gen.tsx
@@ -2,7 +2,7 @@
 import { Fragment } from 'react'
 import { Action, ActionClient } from '@tanstack/react-actions'
 import { Loader, LoaderClient } from '@tanstack/react-loaders'
-import { lazy, Outlet, ReactRouter, RootRoute, Route, RouterProvider } from '@tanstack/react-router'
+import { lazy, Outlet, Router, RootRoute, Route, RouterProvider } from '@tanstack/router'
 
 import App from './pages/_app'
 import NoMatch from './pages/404'
@@ -66,10 +66,10 @@ const config = root.addChildren([
   _404,
 ])
 
-const router = new ReactRouter({ routeTree: config })
+const router = new Router({ routeTree: config })
 export const Routes = () => <RouterProvider router={router} />
 
-declare module '@tanstack/react-router' {
+declare module '@tanstack/router' {
   interface Register {
     router: typeof router
   }

--- a/plugins/tanstack-react-router/readme.md
+++ b/plugins/tanstack-react-router/readme.md
@@ -11,7 +11,7 @@ In case you don't have a Vite project with React and TypeScript, check [Vite doc
 ### Installation
 
 ```shell
-pnpm add @generouted/tanstack-react-router @tanstack/react-router@beta
+pnpm add @generouted/tanstack-react-router @tanstack/router@beta
 ```
 
 Optional additional packages for actions and/or loaders:
@@ -67,7 +67,7 @@ export default function Home() {
 ```tsx
 // src/pages/_app.tsx
 
-import { Outlet } from '@tanstack/react-router'
+import { Outlet } from '@tanstack/router'
 
 export default function App() {
   return (

--- a/plugins/tanstack-react-router/src/template.ts
+++ b/plugins/tanstack-react-router/src/template.ts
@@ -1,6 +1,6 @@
 export const template = `// Generouted, changes to this file will be overriden
 import { Fragment } from 'react'// actions-imports// loaders-imports
-import { lazy, Outlet, ReactRouter, RootRoute, Route, RouterProvider } from '@tanstack/react-router'
+import { lazy, Outlet, Router, RootRoute, Route, RouterProvider } from '@tanstack/router'
 
 // imports
 
@@ -11,10 +11,10 @@ const config = root.addChildren([
   _404,
 ])
 
-const router = new ReactRouter({ routeTree: config })
+const router = new Router({ routeTree: config })
 export const Routes = () => <RouterProvider router={router} />
 
-declare module '@tanstack/react-router' {
+declare module '@tanstack/router' {
   interface Register {
     router: typeof router
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,9 +298,9 @@ importers:
       '@tanstack/react-loaders':
         specifier: ^0.0.1-beta.73
         version: 0.0.1-beta.73(react-dom@18.2.0)(react@18.2.0)
-      '@tanstack/react-router':
-        specifier: ^0.0.1-beta.74
-        version: 0.0.1-beta.74(react-dom@18.2.0)(react@18.2.0)
+      '@tanstack/router':
+        specifier: ^0.0.1-beta.89
+        version: 0.0.1-beta.89(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -2164,20 +2164,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /@tanstack/react-router@0.0.1-beta.74(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-ce3+nWdAGM9e9+rAM+adROK5UYvZNv81ewq1oXJjrAM+edHvDPgFrL3dYtHo95hT3iCv/F0vxhz6ZgjEbE/YAg==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '>=16'
-      react-dom: '>=16'
-    dependencies:
-      '@babel/runtime': 7.18.6
-      '@tanstack/react-store': 0.0.1-beta.62(react-dom@18.2.0)(react@18.2.0)
-      '@tanstack/router': 0.0.1-beta.74
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
   /@tanstack/react-store@0.0.1-beta.62(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-8sv1E1/yo3/7WfEadibQM4lkWKx6CYX6JnW7Lj5gOMgIXACYQax1wjxwYiKyfRM147CJi/yKBW0X9ZoV+0GUyw==}
     engines: {node: '>=12'}
@@ -2191,18 +2177,41 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  /@tanstack/router@0.0.1-beta.74:
-    resolution: {integrity: sha512-FyJUTuZH7bCit1KA9GQqW/E23FjSDhbd3yGRUGNVkQB9VTzl/bWiWOlFM6/RSFMLYRLCqFAyL25DSAKKBsy2Vg==}
+  /@tanstack/react-store@0.0.1-beta.89(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-cSUKpB9acuvuVcrqDMddz/dRYCrt/gxefckX0C30hTTnwhonX+kcFXvhbazAROsJT1ZkBAJmJFvjXy8TLFQdUw==}
     engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      '@tanstack/store': 0.0.1-beta.89
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      use-sync-external-store: 1.2.0(react@18.2.0)
+    dev: false
+
+  /@tanstack/router@0.0.1-beta.89(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-HSQshMk1+keZ/veRKW5BzE3xXBG/Cdhxuu3D4FiVft71Q9Io++PyokGxcFmjSgmMmM070lQaIAY36CfKAesQgQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
     dependencies:
       '@babel/runtime': 7.18.6
-      '@tanstack/store': 0.0.1-beta.62
+      '@tanstack/react-store': 0.0.1-beta.89(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       tiny-invariant: 1.3.1
       tiny-warning: 1.0.3
     dev: false
 
   /@tanstack/store@0.0.1-beta.62:
     resolution: {integrity: sha512-0XNKx+H7Wj/mt4hqWIDQcWtGiVInWqwSQY1JkQwf5vzhG10hpRsnvnufcVQc5MDPXPt/4PDHlJAVUp2gj7OCKA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /@tanstack/store@0.0.1-beta.89:
+    resolution: {integrity: sha512-YW2aAhsXI4QYLXRnxZzB7MgEah91itQcWAjN3GYg1HKHxPv/11T5bL1CUCSxFLTI0f+45uNRjsmof6eqsN3ECA==}
     engines: {node: '>=12'}
     dev: false
 


### PR DESCRIPTION
Newer versions of Tanstack Router have some breaking changes to the package and API names.

* `@tanstack/react-router@beta` has been changed to `@tanstack/router@beta` - [docs](https://tanstack.com/router/v1/docs/installation)
* `ReactRouter` has been changed to `Router` - [docs](https://tanstack.com/router/v1/docs/guide/routes#creating-a-router)

This PR updates the generator code for both changes as well as the example for Tanstack router. 