### PR TITLE
fix: normalize path for windows

### DIFF
--- a/plugins/react-router/src/plugin/index.ts
+++ b/plugins/react-router/src/plugin/index.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import { Plugin } from 'vite'
 
 import { generate } from './generate'
@@ -10,7 +11,8 @@ export default function Generouted(options?: Partial<Options>): Plugin {
     name: 'generouted/react-router',
     enforce: 'pre',
     configureServer(server) {
-      const listener = (path: string) => (path.includes('/src/pages/') ? generate(resolvedOptions) : null)
+      const pagesDir = path.normalize('/src/pages/')
+      const listener = (path: string) => (path.includes(pagesDir) ? generate(resolvedOptions) : null)
       server.watcher.on('add', listener)
       server.watcher.on('change', listener)
       server.watcher.on('unlink', listener)


### PR DESCRIPTION
Hi! I really like this project 😊, 

we recently started using the react-router plugin because of it's simplicity. Our entire team (of university students) uses Windows on our computers, and we all had the same issue: **generouted only scanned the routes at build, but never when vite hot reloads**.

After digging through some of the code, I find that the plugin subscribes a `listener` to the vite server to listen for file changes, triggering a new scanning if a file inside the pages directory changed.
```js
// plugins/react-router/src/plugin/index.ts
    // ...
    configureServer(server) {
      const listener = (path: string) => (path.includes('/src/pages/') ? generate(resolvedOptions) : null)
      server.watcher.on('add', listener)
      server.watcher.on('change', listener)
      server.watcher.on('unlink', listener)
    },
    // ...
```
But given that Windows uses backslashes ('\\'), the paths that `listener` receives on a windows computer would never include '/src/pages/' (at least to my somewhat limited understanding), because they have a format like 'C:\Users\user\project\src\pages\index.tsx'.

The fix, that worked for everyone in my team, is normalizing that `/src/pages/` string literal. This PR implements that fix.

Please let me know if anything more should be done to solve this issue.