### PR TITLE
Fix: Update generouted to support TanStack Router's lazy method name change

### DIFF
--- a/examples/tanstack-react-router/package.json
+++ b/examples/tanstack-react-router/package.json
@@ -13,7 +13,7 @@
     "@generouted/tanstack-react-router": "^1.15.3",
     "@tanstack/react-actions": "^0.0.1-beta.64",
     "@tanstack/react-loaders": "^0.0.1-beta.73",
-    "@tanstack/router": "^0.0.1-beta.89",
+    "@tanstack/router": "^0.0.1-beta.142",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/tanstack-react-router/src/routes.gen.tsx
+++ b/examples/tanstack-react-router/src/routes.gen.tsx
@@ -2,7 +2,7 @@
 import { Fragment } from 'react'
 import { Action, ActionClient } from '@tanstack/react-actions'
 import { Loader, LoaderClient } from '@tanstack/react-loaders'
-import { lazy, Outlet, Router, RootRoute, Route, RouterProvider } from '@tanstack/router'
+import { lazyRouteComponent, Outlet, Router, RootRoute, Route, RouterProvider } from '@tanstack/router'
 
 import App from './pages/_app'
 import NoMatch from './pages/404'
@@ -12,40 +12,44 @@ const _404 = new Route({ getParentRoute: () => root, path: '*', component: NoMat
 const posts = new Route({
   getParentRoute: () => root,
   path: 'posts',
-  component: lazy(() => import('./pages/posts/_layout')),
+  component: lazyRouteComponent(() => import('./pages/posts/_layout')),
 })
 const postsindex = new Route({
   getParentRoute: () => posts,
   path: '/',
-  component: lazy(() => import('./pages/posts/index')),
+  component: lazyRouteComponent(() => import('./pages/posts/index')),
 })
 const postsid = new Route({
   getParentRoute: () => posts,
   path: '$id',
-  component: lazy(() => import('./pages/posts/[id]')),
+  component: lazyRouteComponent(() => import('./pages/posts/[id]')),
 })
 const auth = new Route({
   getParentRoute: () => root,
   id: 'auth',
-  component: lazy(() => import('./pages/(auth)/_layout')),
+  component: lazyRouteComponent(() => import('./pages/(auth)/_layout')),
 })
 const authregister = new Route({
   getParentRoute: () => auth,
   path: 'register',
-  component: lazy(() => import('./pages/(auth)/register')),
+  component: lazyRouteComponent(() => import('./pages/(auth)/register')),
 })
 const authlogin = new Route({
   getParentRoute: () => auth,
   path: 'login',
-  component: lazy(() => import('./pages/(auth)/login')),
+  component: lazyRouteComponent(() => import('./pages/(auth)/login')),
 })
-const about = new Route({ getParentRoute: () => root, path: 'about', component: lazy(() => import('./pages/about')) })
+const about = new Route({
+  getParentRoute: () => root,
+  path: 'about',
+  component: lazyRouteComponent(() => import('./pages/about')),
+})
 const index = new Route({
   getParentRoute: () => root,
   path: '/',
-  component: lazy(() => import('./pages/index')),
-  pendingComponent: lazy(() => import('./pages/index').then((m) => ({ default: m.Pending }))),
-  errorComponent: lazy(() => import('./pages/index').then((m) => ({ default: m.Catch }))),
+  component: lazyRouteComponent(() => import('./pages/index')),
+  pendingComponent: lazyRouteComponent(() => import('./pages/index').then((m) => ({ default: m.Pending }))),
+  errorComponent: lazyRouteComponent(() => import('./pages/index').then((m) => ({ default: m.Catch }))),
 })
 
 const indexAction = new Action({

--- a/plugins/tanstack-react-router/src/generate.ts
+++ b/plugins/tanstack-react-router/src/generate.ts
@@ -42,9 +42,9 @@ const generateRoutes = async () => {
       }
 
       return {
-        _component: `lazy(() => ${module})`,
-        _pendingComponent: pending ? `lazy(() => ${module}.then((m) => ({ default: m.Pending })))` : '',
-        _errorComponent: catch_ ? `lazy(() => ${module}.then((m) => ({ default: m.Catch })))` : '',
+        _component: `lazyRouteComponent(() => ${module})`,
+        _pendingComponent: pending ? `lazyRouteComponent(() => ${module}.then((m) => ({ default: m.Pending })))` : '',
+        _errorComponent: catch_ ? `lazyRouteComponent(() => ${module}.then((m) => ({ default: m.Catch })))` : '',
       }
     },
     patterns,

--- a/plugins/tanstack-react-router/src/template.ts
+++ b/plugins/tanstack-react-router/src/template.ts
@@ -1,6 +1,6 @@
 export const template = `// Generouted, changes to this file will be overriden
 import { Fragment } from 'react'// actions-imports// loaders-imports
-import { lazy, Outlet, Router, RootRoute, Route, RouterProvider } from '@tanstack/router'
+import { lazyRouteComponent, Outlet, Router, RootRoute, Route, RouterProvider } from '@tanstack/router'
 
 // imports
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,8 +299,8 @@ importers:
         specifier: ^0.0.1-beta.73
         version: 0.0.1-beta.73(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/router':
-        specifier: ^0.0.1-beta.89
-        version: 0.0.1-beta.89(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^0.0.1-beta.142
+        version: 0.0.1-beta.142(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -2199,8 +2199,8 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  /@tanstack/router@0.0.1-beta.89(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-HSQshMk1+keZ/veRKW5BzE3xXBG/Cdhxuu3D4FiVft71Q9Io++PyokGxcFmjSgmMmM070lQaIAY36CfKAesQgQ==}
+  /@tanstack/router@0.0.1-beta.142(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-l2wjuhToj5OKXRjdwTkxhmtmXqPsjp9Tu2GwfUDN2PMNveel8EG8SKVvknQnGRNke9+wlumOMPTMe8T+VbFPKw==}
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=16'


### PR DESCRIPTION
Hi, thank you for providing such a useful package!

The lazy method in TanStack Router has been renamed to lazyRouteComponent, causing generouted to not function correctly. In this PR, we update the lazy method name in generouted to resolve the issue.
Changes:
- Update the lazy method to lazyRouteComponent in generate.ts and template.ts files

https://github.com/TanStack/router/commit/642a33448f05ebf1ad958a559856592e1ddabfb8
https://github.com/TanStack/router/commit/5955cbf4e16e0b78fbb0e45a065df9b4b1296b08#diff-be3d1b829369284d7d4c9e17448bd12599133e1cdf35ca266bad2b2fca077d7fR51