### PR TITLE
fix: add types for splat params

### DIFF
--- a/examples/react-router-custom-path/client/src/router.ts
+++ b/examples/react-router-custom-path/client/src/router.ts
@@ -12,12 +12,13 @@ export type Path =
   | `/posts/:id/:pid?`
   | `/posts/:id/deep`
   | `/register`
-  | `/splat/${string}`
+  | `/splat/*`
 
 export type Params = {
   '/posts/:id': { id: string }
   '/posts/:id/:pid?': { id: string; pid?: string }
   '/posts/:id/deep': { id: string }
+  '/splat/*': { '*': string }
 }
 
 export type ModalPath = `/modal`

--- a/examples/react-router-custom/src/router.ts
+++ b/examples/react-router-custom/src/router.ts
@@ -12,12 +12,13 @@ export type Path =
   | `/posts/:id/:pid?`
   | `/posts/:id/deep`
   | `/register`
-  | `/splat/${string}`
+  | `/splat/*`
 
 export type Params = {
   '/posts/:id': { id: string }
   '/posts/:id/:pid?': { id: string; pid?: string }
   '/posts/:id/deep': { id: string }
+  '/splat/*': { '*': string }
 }
 
 export type ModalPath = `/modal`

--- a/examples/react-router-route-modals/src/router.ts
+++ b/examples/react-router-route-modals/src/router.ts
@@ -14,13 +14,14 @@ export type Path =
   | `/posts/:id/:pid?`
   | `/posts/:id/deep`
   | `/register`
-  | `/splat/${string}`
+  | `/splat/*`
 
 export type Params = {
   '/gallery/:id': { id: string }
   '/posts/:id': { id: string }
   '/posts/:id/:pid?': { id: string; pid?: string }
   '/posts/:id/deep': { id: string }
+  '/splat/*': { '*': string }
 }
 
 export type ModalPath = `/modal`

--- a/examples/react-router/src/router.ts
+++ b/examples/react-router/src/router.ts
@@ -12,12 +12,13 @@ export type Path =
   | `/posts/:id/:pid?`
   | `/posts/:id/deep`
   | `/register`
-  | `/splat/${string}`
+  | `/splat/*`
 
 export type Params = {
   '/posts/:id': { id: string }
   '/posts/:id/:pid?': { id: string; pid?: string }
   '/posts/:id/deep': { id: string }
+  '/splat/*': { '*': string }
 }
 
 export type ModalPath = `/modal`

--- a/packages/react-router/src/plugin/generate.ts
+++ b/packages/react-router/src/plugin/generate.ts
@@ -35,7 +35,10 @@ const generateRouteTypes = async (options: Options) => {
         params.push(`'/${path}': { ${param.map((p) => p.replace(/:(.+)(\?)?/, '$1$2:') + ' string').join('; ')} }`)
       }
 
-      if (path.includes('*')) return '/' + path.replace(/\*/g, '${string}')
+      if (path.includes('*')) {
+        params.push(`'/${path}': { '*': string }`)
+        return '/' + path.replace(/\*/g, '${string}')
+      }
       return path.length > 1 ? `/${path}` : path
     }
   })

--- a/packages/react-router/src/plugin/generate.ts
+++ b/packages/react-router/src/plugin/generate.ts
@@ -29,13 +29,14 @@ const generateRouteTypes = async (options: Options) => {
       .join('/')
 
     if (path) {
-      const param = path.split('/').filter((segment) => segment.startsWith(':') || segment.includes('*'))
+      const param = path.split('/').filter((segment) => segment.startsWith(':'))
 
-      if (param.length) {
-        params.push(`'/${path}': { ${param.map((p) => p.replace(/:(.+)(\?)?/, '$1$2:').replace(/(\*)(\?)?/, "'$1$2':") + ' string').join('; ')} }`)
+      if (param.length || path.includes('*')) {
+        const dynamic = param.length ? param.map((p) => p.replace(/:(.+)(\?)?/, '$1$2:') + ' string') : []
+        const splat = path.includes('*') ? ["'*': string"] : []
+        params.push(`'/${path}': { ${[...dynamic, ...splat].join('; ')} }`)
       }
 
-      if (path.includes('*')) return '/' + path.replace(/\*/g, '${string}')
       return path.length > 1 ? `/${path}` : path
     }
   })

--- a/packages/react-router/src/plugin/generate.ts
+++ b/packages/react-router/src/plugin/generate.ts
@@ -29,16 +29,13 @@ const generateRouteTypes = async (options: Options) => {
       .join('/')
 
     if (path) {
-      const param = path.split('/').filter((segment) => segment.startsWith(':'))
+      const param = path.split('/').filter((segment) => segment.startsWith(':') || segment.includes('*'))
 
       if (param.length) {
-        params.push(`'/${path}': { ${param.map((p) => p.replace(/:(.+)(\?)?/, '$1$2:') + ' string').join('; ')} }`)
+        params.push(`'/${path}': { ${param.map((p) => p.replace(/:(.+)(\?)?/, '$1$2:').replace(/(\*)(\?)?/, "'$1$2':") + ' string').join('; ')} }`)
       }
 
-      if (path.includes('*')) {
-        params.push(`'/${path}': { '*': string }`)
-        return '/' + path.replace(/\*/g, '${string}')
-      }
+      if (path.includes('*')) return '/' + path.replace(/\*/g, '${string}')
       return path.length > 1 ? `/${path}` : path
     }
   })

--- a/packages/solid-router/src/plugin/generate.ts
+++ b/packages/solid-router/src/plugin/generate.ts
@@ -35,7 +35,10 @@ const generateRouteTypes = async (options: Options) => {
         params.push(`'/${path}': { ${param.map((p) => p.replace(/:(.+)(\?)?/, '$1$2:') + ' string').join('; ')} }`)
       }
 
-      if (path.includes('*')) return '/' + path.replace(/\*/g, '${string}')
+      if (path.includes('*')) {
+        params.push(`'/${path}': { '*': string }`)
+        return '/' + path.replace(/\*/g, '${string}')
+      }
       return path.length > 1 ? `/${path}` : path
     }
   })

--- a/packages/solid-router/src/plugin/generate.ts
+++ b/packages/solid-router/src/plugin/generate.ts
@@ -29,13 +29,14 @@ const generateRouteTypes = async (options: Options) => {
       .join('/')
 
     if (path) {
-      const param = path.split('/').filter((segment) => segment.startsWith(':') || segment.includes('*'))
+      const param = path.split('/').filter((segment) => segment.startsWith(':'))
 
-      if (param.length) {
-        params.push(`'/${path}': { ${param.map((p) => p.replace(/:(.+)(\?)?/, '$1$2:').replace(/(\*)(\?)?/, "'$1$2':") + ' string').join('; ')} }`)
+      if (param.length || path.includes('*')) {
+        const dynamic = param.length ? param.map((p) => p.replace(/:(.+)(\?)?/, '$1$2:') + ' string') : []
+        const splat = path.includes('*') ? ["'*': string"] : []
+        params.push(`'/${path}': { ${[...dynamic, ...splat].join('; ')} }`)
       }
 
-      if (path.includes('*')) return '/' + path.replace(/\*/g, '${string}')
       return path.length > 1 ? `/${path}` : path
     }
   })

--- a/packages/solid-router/src/plugin/generate.ts
+++ b/packages/solid-router/src/plugin/generate.ts
@@ -29,16 +29,13 @@ const generateRouteTypes = async (options: Options) => {
       .join('/')
 
     if (path) {
-      const param = path.split('/').filter((segment) => segment.startsWith(':'))
+      const param = path.split('/').filter((segment) => segment.startsWith(':') || segment.includes('*'))
 
       if (param.length) {
-        params.push(`'/${path}': { ${param.map((p) => p.replace(/:(.+)(\?)?/, '$1$2:') + ' string').join('; ')} }`)
+        params.push(`'/${path}': { ${param.map((p) => p.replace(/:(.+)(\?)?/, '$1$2:').replace(/(\*)(\?)?/, "'$1$2':") + ' string').join('; ')} }`)
       }
 
-      if (path.includes('*')) {
-        params.push(`'/${path}': { '*': string }`)
-        return '/' + path.replace(/\*/g, '${string}')
-      }
+      if (path.includes('*')) return '/' + path.replace(/\*/g, '${string}')
       return path.length > 1 ? `/${path}` : path
     }
   })


### PR DESCRIPTION
Following the example, `router.ts` file will be like this:

```typescript
export type Path =
  | `/`
  | `/about`
  | `/posts`
  | `/posts/:id`
  | `/posts/:id/:pid?`
  | `/posts/:id/deep`
  | `/splat/${string}`

export type Params = {
  '/posts/:id': { id: string }
  '/posts/:id/:pid?': { id: string; pid?: string }
  '/posts/:id/deep': { id: string }
  '/splat/*': { '*': string }
}
```

adding `'/splat/*': { '*': string }` because "useParams" in a splat file will return an object with one key

```typescript
export default function SplatAll() {
  const path = useParams('/splat/*')
  return <h1>All - {JSON.stringify(path)}</h1>
}
```

http://.../splat/asdf/a/d/b/e
```
path === { "*" : "asdf/a/d/b/e" }
```