### PR TITLE
Fix async nature of generate with buildStart hook

### DIFF
--- a/packages/react-router/src/plugin/index.ts
+++ b/packages/react-router/src/plugin/index.ts
@@ -16,8 +16,8 @@ export default function Generouted(options?: Partial<Options>): Plugin {
       server.watcher.on('change', listener)
       server.watcher.on('unlink', listener)
     },
-    buildStart() {
-      generate(resolvedOptions)
+    buildStart(): Promise<void> {
+      return generate(resolvedOptions)
     },
   }
 }

--- a/packages/solid-router/src/plugin/index.ts
+++ b/packages/solid-router/src/plugin/index.ts
@@ -16,8 +16,8 @@ export default function Generouted(options?: Partial<Options>): Plugin {
       server.watcher.on('change', listener)
       server.watcher.on('unlink', listener)
     },
-    buildStart() {
-      generate(resolvedOptions)
+    buildStart(): Promise<void> {
+      return generate(resolvedOptions)
     },
   }
 }

--- a/packages/tanstack-react-router/src/index.ts
+++ b/packages/tanstack-react-router/src/index.ts
@@ -16,8 +16,8 @@ export default function Generouted(options?: Partial<Options>): Plugin {
       server.watcher.on('change', listener)
       server.watcher.on('unlink', listener)
     },
-    buildStart() {
-      generate(resolvedOptions)
+    buildStart(): Promise<void> {
+      return generate(resolvedOptions)
     },
   }
 }


### PR DESCRIPTION
### Problem
Ran into an issue where the vite/rollup build tries to process a partially generated output file from generouted.

### Context
Opened an issue [here](https://github.com/oedotme/generouted/issues/149)

### Fix Description
Updated `buildStart` to enforce this through types (return `Promise<void>` and then return the value from `generate`.