### PR TITLE
Make output prettier format synchronous

### DIFF
--- a/packages/react-router/src/plugin/generate.ts
+++ b/packages/react-router/src/plugin/generate.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process'
+import { execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
@@ -78,5 +78,5 @@ export const generate = async (options: Options) => {
 
   if (!options.format) return
   const prettier = path.resolve('./node_modules/.bin/prettier')
-  if (fs.existsSync(prettier)) exec(`${prettier} --write --cache ${options.output}`)
+  if (fs.existsSync(prettier)) execSync(`${prettier} --write --cache ${options.output}`)
 }

--- a/packages/solid-router/src/plugin/generate.ts
+++ b/packages/solid-router/src/plugin/generate.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process'
+import { execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
@@ -78,5 +78,5 @@ export const generate = async (options: Options) => {
 
   if (!options.format) return
   const prettier = path.resolve('./node_modules/.bin/prettier')
-  if (fs.existsSync(prettier)) exec(`${prettier} --write --cache ${options.output}`)
+  if (fs.existsSync(prettier)) execSync(`${prettier} --write --cache ${options.output}`)
 }

--- a/packages/tanstack-react-router/src/format.ts
+++ b/packages/tanstack-react-router/src/format.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process'
+import { execSync } from 'child_process'
 import { existsSync } from 'fs'
 import path from 'path'
 
@@ -6,5 +6,5 @@ const prettier = path.resolve('./node_modules/.bin/prettier')
 
 export const format = (file: string) => {
   if (!existsSync(prettier) || !existsSync(file)) return
-  exec(`${prettier} --write --cache ${file}`)
+  execSync(`${prettier} --write --cache ${file}`)
 }


### PR DESCRIPTION
### Problem
Found one more source of async disk writing that can break the vite/rollup build similar to [this issue](https://github.com/oedotme/generouted/issues/149) previously reported.

### Fix Description
Use `execSync` instead of `exec` to execute `prettier` file formatting.

