### PR TITLE
feat: add transpile option

### DIFF
--- a/packages/react-router/src/plugin/generate.ts
+++ b/packages/react-router/src/plugin/generate.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { createLogger } from 'vite'
 import { patterns } from '@generouted/core'
 import fg from 'fast-glob'
+import ts from 'typescript'
 
 import { Options } from './options'
 import { template } from './template'
@@ -57,7 +58,9 @@ const generateRouteTypes = async (options: Options) => {
     '\n\n' +
     `export type ModalPath = "${modals.sort().join('" | "') || 'never'}"`.replace(/"/g, modals.length ? '`' : '')
 
-  const content = template.replace('// types', types)
+  let content = template.replace('// types', types)
+  if (options.transpile) content = ts.transpile(content, { target: ts.ScriptTarget.ESNext })
+
   const count = paths.length + modals.length
 
   return { content, count }

--- a/packages/react-router/src/plugin/options.ts
+++ b/packages/react-router/src/plugin/options.ts
@@ -2,10 +2,12 @@ export type Options = {
   source: { routes: string | string[]; modals: string | string[] }
   output: string
   format: boolean
+  transpile: boolean
 }
 
 export const defaultOptions: Options = {
   source: { routes: './src/pages/**/[\\w[-]*.{jsx,tsx,mdx}', modals: './src/pages/**/[+]*.{jsx,tsx,mdx}' },
   output: './src/router.ts',
   format: true,
+  transpile: false,
 }

--- a/packages/solid-router/src/plugin/generate.ts
+++ b/packages/solid-router/src/plugin/generate.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { createLogger } from 'vite'
 import { patterns } from '@generouted/core'
 import fg from 'fast-glob'
+import ts from 'typescript'
 
 import { Options } from './options'
 import { template } from './template'
@@ -57,7 +58,9 @@ const generateRouteTypes = async (options: Options) => {
     '\n\n' +
     `export type ModalPath = "${modals.sort().join('" | "') || 'never'}"`.replace(/"/g, modals.length ? '`' : '')
 
-  const content = template.replace('// types', types)
+  let content = template.replace('// types', types)
+  if (options.transpile) content = ts.transpile(content, { target: ts.ScriptTarget.ESNext })
+
   const count = paths.length + modals.length
 
   return { content, count }

--- a/packages/solid-router/src/plugin/options.ts
+++ b/packages/solid-router/src/plugin/options.ts
@@ -2,10 +2,12 @@ export type Options = {
   source: { routes: string | string[]; modals: string | string[] }
   output: string
   format: boolean
+  transpile: boolean
 }
 
 export const defaultOptions: Options = {
   source: { routes: './src/pages/**/[\\w[-]*.{jsx,tsx,mdx}', modals: './src/pages/**/[+]*.{jsx,tsx,mdx}' },
   output: './src/router.ts',
   format: true,
+  transpile: false,
 }


### PR DESCRIPTION
**Description**
Add `transpile` option to transpile the code inside of generated `router.ts` to ESNext javascript code.

**Motivation**
Fixes #156, as this will allow the generouted plugin to be used in vanilla javascript codebases. This feature is meant to be used in combination with the `output` option to generate a `router.js` file.