### PR TITLE
feat: add new type that allows for typing generated parameterized paths

### DIFF
--- a/examples/react-router-custom-path/client/src/router.ts
+++ b/examples/react-router-custom-path/client/src/router.ts
@@ -14,6 +14,13 @@ export type Path =
   | `/register`
   | `/splat/*`
 
+export type ParameterizedPaths = {
+  '/posts/:id': `/posts/${string}`
+  '/posts/:id/:pid?': `/posts/${string}${`/${string}` | ''}`
+  '/posts/:id/deep': `/posts/${string}/deep`
+  '/splat/*': `/splat/${string}`
+}
+
 export type Params = {
   '/posts/:id': { id: string }
   '/posts/:id/:pid?': { id: string; pid?: string }

--- a/examples/react-router-custom/src/router.ts
+++ b/examples/react-router-custom/src/router.ts
@@ -14,6 +14,13 @@ export type Path =
   | `/register`
   | `/splat/*`
 
+export type ParameterizedPaths = {
+  '/posts/:id': `/posts/${string}`
+  '/posts/:id/:pid?': `/posts/${string}${`/${string}` | ''}`
+  '/posts/:id/deep': `/posts/${string}/deep`
+  '/splat/*': `/splat/${string}`
+}
+
 export type Params = {
   '/posts/:id': { id: string }
   '/posts/:id/:pid?': { id: string; pid?: string }

--- a/examples/react-router-mdx/src/router.ts
+++ b/examples/react-router-mdx/src/router.ts
@@ -15,6 +15,13 @@ export type Path =
   | `/register`
   | `/splat/*`
 
+export type ParameterizedPaths = {
+  '/posts/:id': `/posts/${string}`
+  '/posts/:id/:pid?': `/posts/${string}${`/${string}` | ''}`
+  '/posts/:id/deep': `/posts/${string}/deep`
+  '/splat/*': `/splat/${string}`
+}
+
 export type Params = {
   '/posts/:id': { id: string }
   '/posts/:id/:pid?': { id: string; pid?: string }

--- a/examples/react-router-route-modals/src/router.ts
+++ b/examples/react-router-route-modals/src/router.ts
@@ -16,6 +16,14 @@ export type Path =
   | `/register`
   | `/splat/*`
 
+export type ParameterizedPaths = {
+  '/gallery/:id': `/gallery/${string}`
+  '/posts/:id': `/posts/${string}`
+  '/posts/:id/:pid?': `/posts/${string}${`/${string}` | ''}`
+  '/posts/:id/deep': `/posts/${string}/deep`
+  '/splat/*': `/splat/${string}`
+}
+
 export type Params = {
   '/gallery/:id': { id: string }
   '/posts/:id': { id: string }

--- a/examples/react-router/src/router.ts
+++ b/examples/react-router/src/router.ts
@@ -14,6 +14,13 @@ export type Path =
   | `/register`
   | `/splat/*`
 
+export type ParameterizedPaths = {
+  '/posts/:id': `/posts/${string}`
+  '/posts/:id/:pid?': `/posts/${string}${`/${string}` | ''}`
+  '/posts/:id/deep': `/posts/${string}/deep`
+  '/splat/*': `/splat/${string}`
+}
+
 export type Params = {
   '/posts/:id': { id: string }
   '/posts/:id/:pid?': { id: string; pid?: string }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -160,7 +156,7 @@ importers:
   examples/react-router:
     dependencies:
       '@generouted/react-router':
-        specifier: ^1.18.4
+        specifier: ^1.18.5
         version: link:../../packages/react-router
       react:
         specifier: ^18.2.0
@@ -194,7 +190,7 @@ importers:
   examples/react-router-custom:
     dependencies:
       '@generouted/react-router':
-        specifier: ^1.18.4
+        specifier: ^1.18.5
         version: link:../../packages/react-router
       react:
         specifier: ^18.2.0
@@ -228,7 +224,7 @@ importers:
   examples/react-router-custom-path:
     dependencies:
       '@generouted/react-router':
-        specifier: ^1.18.4
+        specifier: ^1.18.5
         version: link:../../packages/react-router
       react:
         specifier: ^18.2.0
@@ -262,7 +258,7 @@ importers:
   examples/react-router-mdx:
     dependencies:
       '@generouted/react-router':
-        specifier: ^1.18.4
+        specifier: ^1.18.5
         version: link:../../packages/react-router
       '@mdx-js/rollup':
         specifier: ^3.0.1
@@ -299,7 +295,7 @@ importers:
   examples/react-router-route-modals:
     dependencies:
       '@generouted/react-router':
-        specifier: ^1.18.4
+        specifier: ^1.18.5
         version: link:../../packages/react-router
       react:
         specifier: ^18.2.0
@@ -333,7 +329,7 @@ importers:
   examples/solid-router:
     dependencies:
       '@generouted/solid-router':
-        specifier: ^1.18.4
+        specifier: ^1.18.5
         version: link:../../packages/solid-router
       '@solidjs/router':
         specifier: ^0.12.5
@@ -355,7 +351,7 @@ importers:
   examples/tanstack-react-router:
     dependencies:
       '@generouted/tanstack-react-router':
-        specifier: ^1.18.4
+        specifier: ^1.18.5
         version: link:../../packages/tanstack-react-router
       '@tanstack/react-actions':
         specifier: ^0.0.1-beta.64
@@ -398,7 +394,7 @@ importers:
   explorer:
     dependencies:
       '@generouted/react-router':
-        specifier: ^1.18.4
+        specifier: ^1.18.5
         version: link:../packages/react-router
       react:
         specifier: ^18.2.0
@@ -483,7 +479,7 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       generouted:
-        specifier: ^1.18.4
+        specifier: ^1.18.5
         version: link:../generouted
       react:
         specifier: '>=18'
@@ -514,7 +510,7 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       generouted:
-        specifier: ^1.18.4
+        specifier: ^1.18.5
         version: link:../generouted
     devDependencies:
       '@generouted/core':
@@ -5211,11 +5207,6 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /lilconfig@3.1.1:
-    resolution: {integrity: sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==}
-    engines: {node: '>=14'}
-    dev: true
-
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
@@ -6314,22 +6305,6 @@ packages:
       postcss: 8.4.35
     dev: true
 
-  /postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 3.1.1
-      yaml: 2.4.0
-    dev: true
-
   /postcss-load-config@4.0.2(postcss@8.4.35):
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
@@ -7394,7 +7369,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2
+      postcss-load-config: 4.0.2(postcss@8.4.35)
       resolve-from: 5.0.0
       rollup: 4.12.0
       source-map: 0.8.0-beta.0
@@ -8058,12 +8033,6 @@ packages:
     engines: {node: '>= 14'}
     dev: true
 
-  /yaml@2.4.0:
-    resolution: {integrity: sha512-j9iR8g+/t0lArF4V6NE/QCfT+CO7iLqrXAHZbJdo+LfjqP1vR8Fg5bSiaq6Q2lOD1AUEVrEVIgABvBFYojJVYQ==}
-    engines: {node: '>= 14'}
-    hasBin: true
-    dev: true
-
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -8090,3 +8059,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/shared/core/src/index.ts
+++ b/shared/core/src/index.ts
@@ -4,9 +4,16 @@ export const patterns = {
   route: [/^.*\/src\/pages\/|^\/pages\/|\.(jsx|tsx|mdx)$/g, ''],
   splat: [/\[\.{3}\w+\]/g, '*'],
   param: [/\[([^\]]+)\]/g, ':$1'],
+  // replace parameterized segments with a template literal type that allows for defining a parameter value
+  parameterizedParam: [/\[([^\]]+)\]/g, '${string}'],
+  // replace splat segments with a template literal type that allows for defining a parameter value
+  parameterizedSplat: [/\[\.{3}\w+\]/g, '${string}'],
   slash: [/^index$|\./g, '/'],
   optional: [/^-(:?[\w-]+|\*)/, '$1?'],
-} as Record<string, [RegExp, string]>
+  // replaces optional parameters with a template literal type that allows for defining a parameter value, or not
+  optionalParameterized: [/(\/-\${string})/g, '${`/${string}` | ""}'],
+  trailingSlash: [/\/$/g, ''],
+} satisfies Record<string, [RegExp, string]>
 
 const getRouteId = (path: string) => path.replace(...patterns.route).replace(/\W/g, '')
 


### PR DESCRIPTION
Hey, loving this library and we recently migrated our application over to using it (from explicit react-router paths defined in-code). One thing I've found missing in the generated types though are template literals for parameterized path validation.

For example, we have some functions that generate paths on the fly. I'd like to make sure that they return valid paths. 

```ts
function generatePathToDashboard(dashboardId: string) {
  return `/dashboards/${dashboardId}`;
}
```

I can't validate the above function's output currently. What I've added in this PR is a new type (name can be changed 😄) that allows for typing this sort of case. It would look like:

```ts
function generatePathToDashboard(dashboardId: string): ParameterizedPaths['/dashboards/:dashboardId'] {
  // this is now typed. Variations that don't match `/dashboards/${string}` will fail type-checking
  return `/dashboards/${dashboardId}`;
}
```

If you have suggestions for a better way to approach this, I'm all ears. Also, we'd probably want to change some of the variable names in the PR at the very least. 

Thanks again for creating this great library!