### PR TITLE
feat: add memory and hash routing to react-router

### DIFF
--- a/examples/react-router-hash/.gitignore
+++ b/examples/react-router-hash/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/examples/react-router-hash/index.html
+++ b/examples/react-router-hash/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Generouted - Basic example with hash router</title>
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-router-hash/package.json
+++ b/examples/react-router-hash/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@examples/react-router-hash",
+  "private": true,
+  "description": "Generated file-based routes for React Router and Vite plugin example",
+  "author": "Omar Elhawary <oedotme@gmail.com> (https://omarelhawary.me)",
+  "license": "MIT",
+  "scripts": {
+    "dev": "vite dev --port 3000",
+    "build": "vite build",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@generouted/react-router": "^1.18.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.64",
+    "@types/react-dom": "^18.2.21",
+    "@vitejs/plugin-react": "^4.2.1",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.5"
+  }
+}

--- a/examples/react-router-hash/readme.md
+++ b/examples/react-router-hash/readme.md
@@ -1,0 +1,7 @@
+# Generouted + Hash React Router Example
+
+## Preview
+
+Run this example online via [StackBlitz](https://stackblitz.com/github.com/oedotme/generouted/tree/main/examples/react-router-hash):
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github.com/oedotme/generouted/tree/main/examples/react-router-hash)

--- a/examples/react-router-hash/src/main.tsx
+++ b/examples/react-router-hash/src/main.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from 'react-dom/client'
+import { MemoryRoutes } from '@generouted/react-router'
+
+const container = document.getElementById('app')!
+createRoot(container).render(<MemoryRoutes />)

--- a/examples/react-router-hash/src/pages/(auth)/_layout.tsx
+++ b/examples/react-router-hash/src/pages/(auth)/_layout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router-dom'
+
+export default function Layout() {
+  return (
+    <div>
+      <h1>Auth Layout</h1>
+      <Outlet />
+    </div>
+  )
+}

--- a/examples/react-router-hash/src/pages/(auth)/login.tsx
+++ b/examples/react-router-hash/src/pages/(auth)/login.tsx
@@ -1,0 +1,3 @@
+export default function Login() {
+  return <h1>Login</h1>
+}

--- a/examples/react-router-hash/src/pages/(auth)/register.tsx
+++ b/examples/react-router-hash/src/pages/(auth)/register.tsx
@@ -1,0 +1,3 @@
+export default function Register() {
+  return <h1>Register</h1>
+}

--- a/examples/react-router-hash/src/pages/+modal.tsx
+++ b/examples/react-router-hash/src/pages/+modal.tsx
@@ -1,0 +1,25 @@
+import { useLocation } from 'react-router-dom'
+
+import { useModals } from '@/router'
+
+export default function Welcome() {
+  const location = useLocation()
+  const modals = useModals()
+
+  const handleClose = () => modals.close()
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.25)', display: 'grid', placeContent: 'center' }}
+    >
+      <div style={{ position: 'absolute', inset: 0, zIndex: -1 }} onClick={handleClose} />
+      <div style={{ background: 'white', padding: 40, height: 300, width: 600 }}>
+        <h2>Global Modal!</h2>
+        <p>Current pathname: {location.pathname}</p>
+
+        <button onClick={() => modals.close()}>Close</button>
+        <button onClick={() => modals.close({ at: '/login' })}>Close and redirect to /login</button>
+      </div>
+    </div>
+  )
+}

--- a/examples/react-router-hash/src/pages/404.tsx
+++ b/examples/react-router-hash/src/pages/404.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>404</h1>
+}

--- a/examples/react-router-hash/src/pages/_app.tsx
+++ b/examples/react-router-hash/src/pages/_app.tsx
@@ -1,0 +1,47 @@
+import { Outlet } from 'react-router-dom'
+import { Modals } from '@generouted/react-router'
+
+import { Link, useModals, useNavigate, useParams } from '../router'
+
+export const Catch = () => {
+  return <div>Something went wrong... Caught at _app error boundary</div>
+}
+
+export const Pending = () => <div>Loading from _app...</div>
+
+export default function App() {
+  const navigate = useNavigate()
+  const modals = useModals()
+  const { id, pid } = useParams('/posts/:id/:pid?')
+
+  const a = () => navigate('/posts/:id', { params: { id: 'a' } })
+  const b = () => navigate('/posts/:id', { params: { id: '' } })
+  const c = () => navigate(-1)
+  const d = () => navigate('/posts/:id/deep', { params: { id: 'd' } })
+  const e = () => navigate('/posts/:id/deep', { params: { id: 'e' } })
+
+  return (
+    <section style={{ margin: 24 }}>
+      <header style={{ display: 'flex', gap: 24 }}>
+        <Link to="/">Home</Link>
+        <Link to={{ pathname: '/about' }}>About</Link>
+        <Link to="/posts">Posts</Link>
+        <Link to="/posts/:id/:pid?" params={{ id: '1', pid: '2' }}>
+          Posts by id/pid
+        </Link>
+        <Link to="/posts/:id" params={{ id: 'id' }}>
+          Posts by id
+        </Link>
+        <button onClick={() => modals.open('/modal')}>Global modal at current route</button>
+        <button onClick={() => modals.open('/modal', { at: '/about' })}>Global modal at /about</button>
+        <button onClick={e}>navigate to</button>
+      </header>
+
+      <main>
+        <Outlet />
+      </main>
+
+      <Modals />
+    </section>
+  )
+}

--- a/examples/react-router-hash/src/pages/about.tsx
+++ b/examples/react-router-hash/src/pages/about.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <h1>About - Basic</h1>
+}

--- a/examples/react-router-hash/src/pages/index.tsx
+++ b/examples/react-router-hash/src/pages/index.tsx
@@ -1,0 +1,9 @@
+export const Loader = () => 'Route loader'
+export const Action = () => 'Route action'
+export const Catch = () => <div>Something went wrong...</div>
+
+export const Pending = () => <div>Loading...</div>
+
+export default function Home() {
+  return <h1>Home - Basic</h1>
+}

--- a/examples/react-router-hash/src/pages/posts/[id]/-[pid].tsx
+++ b/examples/react-router-hash/src/pages/posts/[id]/-[pid].tsx
@@ -1,0 +1,3 @@
+export default function IdPid() {
+  return <h1>IdPid</h1>
+}

--- a/examples/react-router-hash/src/pages/posts/[id]/deep.tsx
+++ b/examples/react-router-hash/src/pages/posts/[id]/deep.tsx
@@ -1,0 +1,3 @@
+export default function IdDeep() {
+  return <h1>IdDeep</h1>
+}

--- a/examples/react-router-hash/src/pages/posts/[id]/index.tsx
+++ b/examples/react-router-hash/src/pages/posts/[id]/index.tsx
@@ -1,0 +1,11 @@
+import { useMatch } from 'react-router-dom'
+
+import { useParams } from '@/router'
+
+export default function Id() {
+  // const { params } = useMatch('/posts/$id')
+  const { id } = useParams('/posts/:id')
+  const match = useMatch('/posts/:id')
+
+  return <h1>Id</h1>
+}

--- a/examples/react-router-hash/src/pages/posts/_layout.tsx
+++ b/examples/react-router-hash/src/pages/posts/_layout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router-dom'
+
+export default function About() {
+  return (
+    <div>
+      <h1>Posts Layout</h1>
+      <Outlet />
+    </div>
+  )
+}

--- a/examples/react-router-hash/src/pages/posts/index.tsx
+++ b/examples/react-router-hash/src/pages/posts/index.tsx
@@ -1,0 +1,3 @@
+export default function Index() {
+  return <h1>Index</h1>
+}

--- a/examples/react-router-hash/src/pages/splat/[...all].tsx
+++ b/examples/react-router-hash/src/pages/splat/[...all].tsx
@@ -1,0 +1,3 @@
+export default function SplatAll() {
+  return <h1>All</h1>
+}

--- a/examples/react-router-hash/src/router.ts
+++ b/examples/react-router-hash/src/router.ts
@@ -1,0 +1,28 @@
+// Generouted, changes to this file will be overriden
+/* eslint-disable */
+
+import { components, hooks, utils } from '@generouted/react-router/client'
+
+export type Path =
+  | `/`
+  | `/about`
+  | `/login`
+  | `/posts`
+  | `/posts/:id`
+  | `/posts/:id/:pid?`
+  | `/posts/:id/deep`
+  | `/register`
+  | `/splat/*`
+
+export type Params = {
+  '/posts/:id': { id: string }
+  '/posts/:id/:pid?': { id: string; pid?: string }
+  '/posts/:id/deep': { id: string }
+  '/splat/*': { '*': string }
+}
+
+export type ModalPath = `/modal`
+
+export const { Link, Navigate } = components<Path, Params>()
+export const { useModals, useNavigate, useParams } = hooks<Path, Params, ModalPath>()
+export const { redirect } = utils<Path, Params>()

--- a/examples/react-router-hash/tsconfig.json
+++ b/examples/react-router-hash/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "paths": { "@/*": ["src/*"] },
+    "types": ["vite/client"]
+  },
+  "include": ["./src"]
+}

--- a/examples/react-router-hash/vite.config.ts
+++ b/examples/react-router-hash/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import generouted from '@generouted/react-router/plugin'
+
+export default defineConfig({
+  plugins: [react(), generouted()],
+  resolve: { alias: { '@': '/src' } },
+})

--- a/examples/react-router-memory/.gitignore
+++ b/examples/react-router-memory/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/examples/react-router-memory/index.html
+++ b/examples/react-router-memory/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Generouted - Basic example with memory router</title>
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-router-memory/package.json
+++ b/examples/react-router-memory/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@examples/react-router-memory",
+  "private": true,
+  "description": "Generated file-based routes for React Router and Vite plugin example",
+  "author": "Omar Elhawary <oedotme@gmail.com> (https://omarelhawary.me)",
+  "license": "MIT",
+  "scripts": {
+    "dev": "vite dev --port 3000",
+    "build": "vite build",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@generouted/react-router": "^1.18.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.64",
+    "@types/react-dom": "^18.2.21",
+    "@vitejs/plugin-react": "^4.2.1",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.5"
+  }
+}

--- a/examples/react-router-memory/readme.md
+++ b/examples/react-router-memory/readme.md
@@ -1,0 +1,7 @@
+# Generouted + Memory React Router Example
+
+## Preview
+
+Run this example online via [StackBlitz](https://stackblitz.com/github.com/oedotme/generouted/tree/main/examples/react-router-memory):
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github.com/oedotme/generouted/tree/main/examples/react-router-memory)

--- a/examples/react-router-memory/src/main.tsx
+++ b/examples/react-router-memory/src/main.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from 'react-dom/client'
+import { MemoryRoutes } from '@generouted/react-router'
+
+const container = document.getElementById('app')!
+createRoot(container).render(<MemoryRoutes />)

--- a/examples/react-router-memory/src/pages/(auth)/_layout.tsx
+++ b/examples/react-router-memory/src/pages/(auth)/_layout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router-dom'
+
+export default function Layout() {
+  return (
+    <div>
+      <h1>Auth Layout</h1>
+      <Outlet />
+    </div>
+  )
+}

--- a/examples/react-router-memory/src/pages/(auth)/login.tsx
+++ b/examples/react-router-memory/src/pages/(auth)/login.tsx
@@ -1,0 +1,3 @@
+export default function Login() {
+  return <h1>Login</h1>
+}

--- a/examples/react-router-memory/src/pages/(auth)/register.tsx
+++ b/examples/react-router-memory/src/pages/(auth)/register.tsx
@@ -1,0 +1,3 @@
+export default function Register() {
+  return <h1>Register</h1>
+}

--- a/examples/react-router-memory/src/pages/+modal.tsx
+++ b/examples/react-router-memory/src/pages/+modal.tsx
@@ -1,0 +1,25 @@
+import { useLocation } from 'react-router-dom'
+
+import { useModals } from '@/router'
+
+export default function Welcome() {
+  const location = useLocation()
+  const modals = useModals()
+
+  const handleClose = () => modals.close()
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.25)', display: 'grid', placeContent: 'center' }}
+    >
+      <div style={{ position: 'absolute', inset: 0, zIndex: -1 }} onClick={handleClose} />
+      <div style={{ background: 'white', padding: 40, height: 300, width: 600 }}>
+        <h2>Global Modal!</h2>
+        <p>Current pathname: {location.pathname}</p>
+
+        <button onClick={() => modals.close()}>Close</button>
+        <button onClick={() => modals.close({ at: '/login' })}>Close and redirect to /login</button>
+      </div>
+    </div>
+  )
+}

--- a/examples/react-router-memory/src/pages/404.tsx
+++ b/examples/react-router-memory/src/pages/404.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>404</h1>
+}

--- a/examples/react-router-memory/src/pages/_app.tsx
+++ b/examples/react-router-memory/src/pages/_app.tsx
@@ -1,0 +1,47 @@
+import { Outlet } from 'react-router-dom'
+import { Modals } from '@generouted/react-router'
+
+import { Link, useModals, useNavigate, useParams } from '../router'
+
+export const Catch = () => {
+  return <div>Something went wrong... Caught at _app error boundary</div>
+}
+
+export const Pending = () => <div>Loading from _app...</div>
+
+export default function App() {
+  const navigate = useNavigate()
+  const modals = useModals()
+  const { id, pid } = useParams('/posts/:id/:pid?')
+
+  const a = () => navigate('/posts/:id', { params: { id: 'a' } })
+  const b = () => navigate('/posts/:id', { params: { id: '' } })
+  const c = () => navigate(-1)
+  const d = () => navigate('/posts/:id/deep', { params: { id: 'd' } })
+  const e = () => navigate('/posts/:id/deep', { params: { id: 'e' } })
+
+  return (
+    <section style={{ margin: 24 }}>
+      <header style={{ display: 'flex', gap: 24 }}>
+        <Link to="/">Home</Link>
+        <Link to={{ pathname: '/about' }}>About</Link>
+        <Link to="/posts">Posts</Link>
+        <Link to="/posts/:id/:pid?" params={{ id: '1', pid: '2' }}>
+          Posts by id/pid
+        </Link>
+        <Link to="/posts/:id" params={{ id: 'id' }}>
+          Posts by id
+        </Link>
+        <button onClick={() => modals.open('/modal')}>Global modal at current route</button>
+        <button onClick={() => modals.open('/modal', { at: '/about' })}>Global modal at /about</button>
+        <button onClick={e}>navigate to</button>
+      </header>
+
+      <main>
+        <Outlet />
+      </main>
+
+      <Modals />
+    </section>
+  )
+}

--- a/examples/react-router-memory/src/pages/about.tsx
+++ b/examples/react-router-memory/src/pages/about.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <h1>About - Basic</h1>
+}

--- a/examples/react-router-memory/src/pages/index.tsx
+++ b/examples/react-router-memory/src/pages/index.tsx
@@ -1,0 +1,9 @@
+export const Loader = () => 'Route loader'
+export const Action = () => 'Route action'
+export const Catch = () => <div>Something went wrong...</div>
+
+export const Pending = () => <div>Loading...</div>
+
+export default function Home() {
+  return <h1>Home - Basic</h1>
+}

--- a/examples/react-router-memory/src/pages/posts/[id]/-[pid].tsx
+++ b/examples/react-router-memory/src/pages/posts/[id]/-[pid].tsx
@@ -1,0 +1,3 @@
+export default function IdPid() {
+  return <h1>IdPid</h1>
+}

--- a/examples/react-router-memory/src/pages/posts/[id]/deep.tsx
+++ b/examples/react-router-memory/src/pages/posts/[id]/deep.tsx
@@ -1,0 +1,3 @@
+export default function IdDeep() {
+  return <h1>IdDeep</h1>
+}

--- a/examples/react-router-memory/src/pages/posts/[id]/index.tsx
+++ b/examples/react-router-memory/src/pages/posts/[id]/index.tsx
@@ -1,0 +1,11 @@
+import { useMatch } from 'react-router-dom'
+
+import { useParams } from '@/router'
+
+export default function Id() {
+  // const { params } = useMatch('/posts/$id')
+  const { id } = useParams('/posts/:id')
+  const match = useMatch('/posts/:id')
+
+  return <h1>Id</h1>
+}

--- a/examples/react-router-memory/src/pages/posts/_layout.tsx
+++ b/examples/react-router-memory/src/pages/posts/_layout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router-dom'
+
+export default function About() {
+  return (
+    <div>
+      <h1>Posts Layout</h1>
+      <Outlet />
+    </div>
+  )
+}

--- a/examples/react-router-memory/src/pages/posts/index.tsx
+++ b/examples/react-router-memory/src/pages/posts/index.tsx
@@ -1,0 +1,3 @@
+export default function Index() {
+  return <h1>Index</h1>
+}

--- a/examples/react-router-memory/src/pages/splat/[...all].tsx
+++ b/examples/react-router-memory/src/pages/splat/[...all].tsx
@@ -1,0 +1,3 @@
+export default function SplatAll() {
+  return <h1>All</h1>
+}

--- a/examples/react-router-memory/src/router.ts
+++ b/examples/react-router-memory/src/router.ts
@@ -1,0 +1,28 @@
+// Generouted, changes to this file will be overriden
+/* eslint-disable */
+
+import { components, hooks, utils } from '@generouted/react-router/client'
+
+export type Path =
+  | `/`
+  | `/about`
+  | `/login`
+  | `/posts`
+  | `/posts/:id`
+  | `/posts/:id/:pid?`
+  | `/posts/:id/deep`
+  | `/register`
+  | `/splat/*`
+
+export type Params = {
+  '/posts/:id': { id: string }
+  '/posts/:id/:pid?': { id: string; pid?: string }
+  '/posts/:id/deep': { id: string }
+  '/splat/*': { '*': string }
+}
+
+export type ModalPath = `/modal`
+
+export const { Link, Navigate } = components<Path, Params>()
+export const { useModals, useNavigate, useParams } = hooks<Path, Params, ModalPath>()
+export const { redirect } = utils<Path, Params>()

--- a/examples/react-router-memory/tsconfig.json
+++ b/examples/react-router-memory/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "paths": { "@/*": ["src/*"] },
+    "types": ["vite/client"]
+  },
+  "include": ["./src"]
+}

--- a/examples/react-router-memory/vite.config.ts
+++ b/examples/react-router-memory/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import generouted from '@generouted/react-router/plugin'
+
+export default defineConfig({
+  plugins: [react(), generouted()],
+  resolve: { alias: { '@': '/src' } },
+})

--- a/packages/generouted/readme.md
+++ b/packages/generouted/readme.md
@@ -99,6 +99,8 @@ export default defineConfig({ plugins: [react(), generouted()] })
 
 #### Usage
 
+##### `<Routes />` for browser routing
+
 ```tsx
 // src/main.tsx
 
@@ -106,6 +108,28 @@ import { createRoot } from 'react-dom/client'
 import { Routes } from '@generouted/react-router'
 
 createRoot(document.getElementById('root')!).render(<Routes />)
+```
+
+##### `<HashRoutes />` for browser routing
+
+```tsx
+// src/main.tsx
+
+import { createRoot } from 'react-dom/client'
+import { HashRoutes } from '@generouted/react-router'
+
+createRoot(document.getElementById('root')!).render(<HashRoutes />)
+```
+
+##### `<MemoryRoutes />` for browser routing
+
+```tsx
+// src/main.tsx
+
+import { createRoot } from 'react-dom/client'
+import { MemoryRoutes } from '@generouted/react-router'
+
+createRoot(document.getElementById('root')!).render(<MemoryRoutes />)
 ```
 
 #### Adding pages
@@ -411,7 +435,7 @@ src/pages
 
 Via [`@generouted/react-router`](/packages/react-router) or [`@generouted/solid-router`](/packages/solid-router)
 
-- `<Routes />` — file-based routing component to be render in the app entry
+- `<Routes />`, `<HashRoutes />`, `<MemoryRoutes />` — file-based routing component to be render in the app entry
 - `<Modals />` — optional file-based modals component to be render in the `_app.tsx` layout
 - `routes` — file-based routes tree/object used by default at `<Routes />` component
 
@@ -421,7 +445,7 @@ Via `@generouted/react-router/lazy` or `@generouted/solid-router/lazy`
 
 - Used instead of `@generouted/react-router` or `@generouted/solid-router` to enable lazy-loading
 - Make sure to replace all imports to lazy imports — namely at app entry and `src/pages/_app.tsx`
-- Provides the same `<Routes />`, `<Modals />` and `routes` exports
+- Provides the same `<Routes />`, `<HashRoutes />`, `<MemoryRoutes />`, `<Modals />` and `routes` exports
 
 ### Plugins
 

--- a/packages/generouted/src/react-router-lazy.tsx
+++ b/packages/generouted/src/react-router-lazy.tsx
@@ -1,5 +1,12 @@
 import { Fragment, Suspense } from 'react'
-import { createBrowserRouter, Outlet, RouterProvider, useLocation } from 'react-router-dom'
+import {
+  createBrowserRouter,
+  createHashRouter,
+  createMemoryRouter,
+  Outlet,
+  RouterProvider,
+  useLocation,
+} from 'react-router-dom'
 import type { ActionFunction, RouteObject, LoaderFunction } from 'react-router-dom'
 
 import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } from './core'
@@ -45,6 +52,8 @@ const fallback = { path: '*', Component: _404?.default || Fragment }
 
 export const routes: RouteObject[] = [{ ...app, children: [...regularRoutes, fallback] }]
 export const Routes = () => <RouterProvider router={createBrowserRouter(routes)} />
+export const MemoryRoutes = () => <RouterProvider router={createMemoryRouter(routes)} />
+export const HashRoutes = () => <RouterProvider router={createHashRouter(routes)} />
 
 export const Modals = () => {
   const Modal = modalRoutes[useLocation().state?.modal] || Fragment

--- a/packages/generouted/src/react-router.tsx
+++ b/packages/generouted/src/react-router.tsx
@@ -1,5 +1,12 @@
 import { Fragment, Suspense } from 'react'
-import { createBrowserRouter, Outlet, RouterProvider, useLocation } from 'react-router-dom'
+import {
+  createBrowserRouter,
+  createHashRouter,
+  createMemoryRouter,
+  Outlet,
+  RouterProvider,
+  useLocation,
+} from 'react-router-dom'
 import type { ActionFunction, RouteObject, LoaderFunction } from 'react-router-dom'
 
 import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } from './core'
@@ -32,6 +39,8 @@ const fallback = { path: '*', Component: _404?.default || Fragment }
 
 export const routes: RouteObject[] = [{ ...app, children: [...regularRoutes, fallback] }]
 export const Routes = () => <RouterProvider router={createBrowserRouter(routes)} />
+export const MemoryRoutes = () => <RouterProvider router={createMemoryRouter(routes)} />
+export const HashRoutes = () => <RouterProvider router={createHashRouter(routes)} />
 
 export const Modals = () => {
   const Modal = modalRoutes[useLocation().state?.modal] || Fragment


### PR DESCRIPTION
Hey! 👋

First of all, thank you for this library, which is an interesting and enjoyable accelerator to use.

On one of my projects using **react-router,** I needed to use memory-routing (via `createMemoryRouter`). Unfortunately, it didn't seem possible with **Generouted**.
Here's a PR that adds `<HashRoutes />` and `<MemoryRoutes />` to the **react-router** implementation.

If you see any adjustments that need to be made, I'll be happy to do them. 🫡

Have a great day ✌️