### PR TITLE
docs: update example link

### DIFF
--- a/packages/tanstack-react-router/readme.md
+++ b/packages/tanstack-react-router/readme.md
@@ -87,7 +87,7 @@ export default function App() {
 
 ### TanStack React Router
 
-- [Basic](../../examples/tanstack-react-router/basic)
+- [Basic](../../examples/tanstack-react-router/)
 
 ## License
 


### PR DESCRIPTION
This PR fixes the example link in the Tanstack Router docs which was pointing to a nonexistent folder.