### PR TITLE
fix: ensure internal browser router is instantiated once

### DIFF
--- a/packages/generouted/src/react-router-lazy.tsx
+++ b/packages/generouted/src/react-router-lazy.tsx
@@ -59,8 +59,15 @@ const app = { Component: _app?.default ? App : Layout, ErrorBoundary: _app?.Catc
 const fallback = { path: '*', Component: _404?.default || Fragment }
 
 export const routes: RouteObject[] = [{ ...app, children: [...regularRoutes, fallback] }]
-const router = () => createBrowserRouter(routes)
-export const Routes = () => <RouterProvider router={router()} />
+
+let router: ReturnType<typeof createBrowserRouter> | undefined
+const getRouter = () => {
+  if (!router) {
+    router = createBrowserRouter(routes)
+  }
+  return router
+}
+export const Routes = () => <RouterProvider router={getRouter()} />
 
 /** @deprecated `<Modals />` is no longer needed, it will be removed in future releases */
 export const Modals = () => (console.warn('[generouted] `<Modals />` will be removed in future releases'), null)

--- a/packages/generouted/src/react-router-lazy.tsx
+++ b/packages/generouted/src/react-router-lazy.tsx
@@ -59,15 +59,9 @@ const app = { Component: _app?.default ? App : Layout, ErrorBoundary: _app?.Catc
 const fallback = { path: '*', Component: _404?.default || Fragment }
 
 export const routes: RouteObject[] = [{ ...app, children: [...regularRoutes, fallback] }]
-
-let router: ReturnType<typeof createBrowserRouter> | undefined
-const getRouter = () => {
-  if (!router) {
-    router = createBrowserRouter(routes)
-  }
-  return router
-}
-export const Routes = () => <RouterProvider router={getRouter()} />
+let router: ReturnType<typeof createBrowserRouter>
+const createRouter = () => ((router ??= createBrowserRouter(routes)), router)
+export const Routes = () => <RouterProvider router={createRouter()} />
 
 /** @deprecated `<Modals />` is no longer needed, it will be removed in future releases */
 export const Modals = () => (console.warn('[generouted] `<Modals />` will be removed in future releases'), null)

--- a/packages/generouted/src/react-router.tsx
+++ b/packages/generouted/src/react-router.tsx
@@ -46,15 +46,9 @@ const app = { Component: _app?.default ? App : Layout, ErrorBoundary: _app?.Catc
 const fallback = { path: '*', Component: _404?.default || Fragment }
 
 export const routes: RouteObject[] = [{ ...app, children: [...regularRoutes, fallback] }]
-
-let router: ReturnType<typeof createBrowserRouter> | undefined
-const getRouter = () => {
-  if (!router) {
-    router = createBrowserRouter(routes)
-  }
-  return router
-}
-export const Routes = () => <RouterProvider router={getRouter()} />
+let router: ReturnType<typeof createBrowserRouter>
+const createRouter = () => ((router ??= createBrowserRouter(routes)), router)
+export const Routes = () => <RouterProvider router={createRouter()} />
 
 /** @deprecated `<Modals />` is no longer needed, it will be removed in future releases */
 export const Modals = () => (console.warn('[generouted] `<Modals />` will be removed in future releases'), null)

--- a/packages/generouted/src/react-router.tsx
+++ b/packages/generouted/src/react-router.tsx
@@ -46,8 +46,15 @@ const app = { Component: _app?.default ? App : Layout, ErrorBoundary: _app?.Catc
 const fallback = { path: '*', Component: _404?.default || Fragment }
 
 export const routes: RouteObject[] = [{ ...app, children: [...regularRoutes, fallback] }]
-const router = () => createBrowserRouter(routes)
-export const Routes = () => <RouterProvider router={router()} />
+
+let router: ReturnType<typeof createBrowserRouter> | undefined
+const getRouter = () => {
+  if (!router) {
+    router = createBrowserRouter(routes)
+  }
+  return router
+}
+export const Routes = () => <RouterProvider router={getRouter()} />
 
 /** @deprecated `<Modals />` is no longer needed, it will be removed in future releases */
 export const Modals = () => (console.warn('[generouted] `<Modals />` will be removed in future releases'), null)


### PR DESCRIPTION
Implement constructing the internal router as a memoized getter so that exactly one instance is created and used no matter how many times the `Routes` component is rendered. Also ensures that the router is not created if the `Routes` component is never rendered.

Fixes #181 