### PR TITLE
fix: catch-all route as folder with index file

### DIFF
--- a/packages/generouted/src/core.test.ts
+++ b/packages/generouted/src/core.test.ts
@@ -54,10 +54,25 @@ test('regular routes generation', () => {
     '/src/pages/docs/-[lang]/index.tsx': {},
     '/src/pages/docs/-[lang]/resources.tsx': {},
     '/src/pages/docs/-en/support.tsx': {},
+    '/src/pages/catchall/folder/[...all]/index.tsx': {},
+    '/src/pages/catchall/file/[...all].tsx': {},
     '/src/pages/index.tsx': {},
   }
 
   expect(generateRegularRoutes(modules, () => ({}))).toStrictEqual([
+    {
+      path: 'catchall',
+      children: [
+        {
+          path: 'file',
+          children: [{ path: '*', id: 'catchall/file/[...all]' }],
+        },
+        {
+          path: 'folder',
+          children: [{ path: '*', id: 'catchall/folder/[...all]/index' }],
+        },
+      ],
+    },
     {
       path: 'docs',
       children: [

--- a/packages/generouted/src/core.ts
+++ b/packages/generouted/src/core.ts
@@ -1,6 +1,6 @@
 export const patterns = {
   route: [/^.*\/src\/pages\/|\.(jsx|tsx|mdx)$/g, ''],
-  splat: [/\[\.{3}\w+\]/g, '*'],
+  splat: [/\[\.{3}\w+\](\/index)?/g, '*'],
   param: [/\[([^\]]+)\]/g, ':$1'],
   slash: [/^index$|\./g, '/'],
   optional: [/^-(:?[\w-]+|\*)/, '$1?'],


### PR DESCRIPTION
Should resolve #190 