### PR TITLE
Avoid usage of extglob to be able to adopt native modules from rolldown-vite

### DIFF
--- a/examples/react-router-custom-path/client/src/routes.tsx
+++ b/examples/react-router-custom-path/client/src/routes.tsx
@@ -7,16 +7,14 @@ import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } f
 type Element = () => JSX.Element
 type Module = { default: Element; Loader?: LoaderFunction; Action?: ActionFunction; Catch?: Element; Pending?: Element }
 
-// Avoid extglobs for rolldown-vite compatibility
-// ref: https://github.com/vitejs/rolldown-vite/issues/365
-const PRESERVED = import.meta.glob<Module>(['/client/src/pages/_app.{jsx,tsx}', '/client/src/pages/404.{jsx,tsx}'], { eager: true })
+const PRESERVED = import.meta.glob<Module>('/client/src/pages/{_app,404}.{jsx,tsx}', { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/client/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(
   [
-    '/client/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
-    '!/client/src/pages/**/_*.{jsx,tsx,mdx}',
+    '/client/src/pages/**/[A-Za-z0-9[-]*.{jsx,tsx,mdx}',
     '/client/src/pages/**/_layout.{jsx,tsx,mdx}',
-    '!/client/src/pages/**/404.{jsx,tsx,mdx}',
+    '!/client/src/pages/404.{jsx,tsx,mdx}',
+    '!/client/src/pages/**/_*/**',
   ],
   { eager: true },
 )

--- a/examples/react-router-custom-path/client/src/routes.tsx
+++ b/examples/react-router-custom-path/client/src/routes.tsx
@@ -7,10 +7,17 @@ import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } f
 type Element = () => JSX.Element
 type Module = { default: Element; Loader?: LoaderFunction; Action?: ActionFunction; Catch?: Element; Pending?: Element }
 
-const PRESERVED = import.meta.glob<Module>('/client/src/pages/(_app|404).{jsx,tsx}', { eager: true })
+// Avoid extglobs for rolldown-vite compatibility
+// ref: https://github.com/vitejs/rolldown-vite/issues/365
+const PRESERVED = import.meta.glob<Module>(['/client/src/pages/_app.{jsx,tsx}', '/client/src/pages/404.{jsx,tsx}'], { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/client/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(
-  ['/client/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}', '!/client/src/pages/**/(_!(layout)*(/*)?|_app|404)*'],
+  [
+    '/client/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
+    '!/client/src/pages/**/_*.{jsx,tsx,mdx}',
+    '/client/src/pages/**/_layout.{jsx,tsx,mdx}',
+    '!/client/src/pages/**/404.{jsx,tsx,mdx}',
+  ],
   { eager: true },
 )
 

--- a/examples/react-router-custom/src/routes.tsx
+++ b/examples/react-router-custom/src/routes.tsx
@@ -7,10 +7,17 @@ import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } f
 type Element = () => JSX.Element
 type Module = { default: Element; Loader?: LoaderFunction; Action?: ActionFunction; Catch?: Element; Pending?: Element }
 
-const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
+// Avoid extglobs for rolldown-vite compatibility
+// ref: https://github.com/vitejs/rolldown-vite/issues/365
+const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(
-  ['/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}', '!/src/pages/**/(_!(layout)*(/*)?|_app|404)*'],
+  [
+    '/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
+    '!/src/pages/**/_*.{jsx,tsx,mdx}',
+    '/src/pages/**/_layout.{jsx,tsx,mdx}',
+    '!/src/pages/**/404.{jsx,tsx,mdx}',
+  ],
   { eager: true },
 )
 

--- a/examples/react-router-custom/src/routes.tsx
+++ b/examples/react-router-custom/src/routes.tsx
@@ -7,16 +7,14 @@ import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } f
 type Element = () => JSX.Element
 type Module = { default: Element; Loader?: LoaderFunction; Action?: ActionFunction; Catch?: Element; Pending?: Element }
 
-// Avoid extglobs for rolldown-vite compatibility
-// ref: https://github.com/vitejs/rolldown-vite/issues/365
-const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
+const PRESERVED = import.meta.glob<Module>('/src/pages/{_app,404}.{jsx,tsx}', { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(
   [
-    '/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
-    '!/src/pages/**/_*.{jsx,tsx,mdx}',
+    '/src/pages/**/[A-Za-z0-9[-]*.{jsx,tsx,mdx}',
     '/src/pages/**/_layout.{jsx,tsx,mdx}',
-    '!/src/pages/**/404.{jsx,tsx,mdx}',
+    '!/src/pages/404.{jsx,tsx,mdx}',
+    '!/src/pages/**/_*/**',
   ],
   { eager: true },
 )

--- a/explorer/src/components/routes.tsx
+++ b/explorer/src/components/routes.tsx
@@ -4,11 +4,19 @@ import { Link, Location, RouteObject, useLocation } from 'react-router'
 import { Arrow, Directory, File } from '@/icons'
 import { classNames } from '@/utils'
 
-const PRESERVED = import.meta.glob('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
+// Avoid extglobs for rolldown-vite compatibility
+// ref: https://github.com/vitejs/rolldown-vite/issues/365
+const PRESERVED = import.meta.glob(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
 const MODALS = import.meta.glob('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
-const ROUTES = import.meta.glob(['/src/pages/**/[\\w[-]*.{jsx,tsx}', '!/src/pages/**/(_!(layout)*(/*)?|_app|404)*'], {
-  eager: true,
-})
+const ROUTES = import.meta.glob(
+  [
+    '/src/pages/**/[\\w[-]*.{jsx,tsx}',
+    '!/src/pages/**/_*.{jsx,tsx}',
+    '/src/pages/**/_layout.{jsx,tsx}',
+    '!/src/pages/**/404.{jsx,tsx}',
+  ],
+  { eager: true },
+)
 
 type Route = RouteObject & Partial<{ key: string; modal: boolean; pathname: string }>
 

--- a/explorer/src/components/routes.tsx
+++ b/explorer/src/components/routes.tsx
@@ -4,16 +4,14 @@ import { Link, Location, RouteObject, useLocation } from 'react-router'
 import { Arrow, Directory, File } from '@/icons'
 import { classNames } from '@/utils'
 
-// Avoid extglobs for rolldown-vite compatibility
-// ref: https://github.com/vitejs/rolldown-vite/issues/365
-const PRESERVED = import.meta.glob(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
+const PRESERVED = import.meta.glob('/src/pages/{_app,404}.{jsx,tsx}', { eager: true })
 const MODALS = import.meta.glob('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob(
   [
-    '/src/pages/**/[\\w[-]*.{jsx,tsx}',
-    '!/src/pages/**/_*.{jsx,tsx}',
+    '/src/pages/**/[A-Za-z0-9[-]*.{jsx,tsx}',
     '/src/pages/**/_layout.{jsx,tsx}',
-    '!/src/pages/**/404.{jsx,tsx}',
+    '!/src/pages/404.{jsx,tsx}',
+    '!/src/pages/**/_*/**',
   ],
   { eager: true },
 )
@@ -48,7 +46,7 @@ const sort = (routes: Route[]) => [
 
 const Tree = ({ routes, depth, location }: { routes: Route[]; depth: number; location: Location }) => {
   return (
-    <ul className="flex select-none flex-col text-sm font-medium">
+    <ul className="flex flex-col text-sm font-medium select-none">
       {routes?.map((route) => {
         const pathname = route.pathname?.startsWith('/') ? route.pathname : `/${route.pathname}`
         const path = pathname!.replace(/\([\w-]+\)\/|\/?_layout/g, '').replace('?', '')
@@ -71,7 +69,7 @@ const Tree = ({ routes, depth, location }: { routes: Route[]; depth: number; loc
                   routes={sort(
                     route.pathname?.includes('_layout')
                       ? [{ id: route.key, pathname: route.pathname }, ...route.children]
-                      : route.children
+                      : route.children,
                   )}
                   depth={depth + 1}
                   location={location}
@@ -83,7 +81,7 @@ const Tree = ({ routes, depth, location }: { routes: Route[]; depth: number; loc
                 className={classNames(
                   'flex space-x-2 py-2.5',
                   location.pathname === path && !pathname.includes('_layout') ? 'bg-slate-50' : '',
-                  disabled ? 'pointer-events-none text-slate-300' : 'text-primary'
+                  disabled ? 'pointer-events-none text-slate-300' : 'text-primary',
                 )}
                 state={route.modal ? { modal: path } : null}
                 style={{ paddingLeft }}
@@ -108,7 +106,7 @@ export const Routes = () => {
   return (
     <header className="w-80">
       <nav className="h-full rounded-lg border border-dashed border-slate-500 bg-white py-6">
-        <section className="flex items-center space-x-3 px-6 pb-6 pt-1 text-primary">
+        <section className="text-primary flex items-center space-x-3 px-6 pt-1 pb-6">
           <img className="h-4 w-4" src="/favicon.svg" />
           <a
             className="flex items-center space-x-1 text-sm font-bold underline"

--- a/packages/generouted/src/react-location.tsx
+++ b/packages/generouted/src/react-location.tsx
@@ -6,10 +6,14 @@ import { generatePreservedRoutes, generateRegularRoutes } from './core'
 type Element = () => JSX.Element
 type Module = { default: Element; Loader: LoaderFn; Pending: Element; Catch: Element }
 
-const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
+// Avoid extglobs for rolldown-vite compatibility
+// ref: https://github.com/vitejs/rolldown-vite/issues/365
+const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
 const ROUTES = import.meta.glob<Module>([
   '/src/pages/**/[\\w[-]*.{jsx,tsx}',
-  '!/src/pages/**/(_!(layout)*(/*)?|_app|404)*',
+  '!/src/pages/**/_*.{jsx,tsx}',
+  '/src/pages/**/_layout.{jsx,tsx}',
+  '!/src/pages/**/404.{jsx,tsx}',
 ])
 
 const preservedRoutes = generatePreservedRoutes<Module>(PRESERVED)

--- a/packages/generouted/src/react-location.tsx
+++ b/packages/generouted/src/react-location.tsx
@@ -6,14 +6,12 @@ import { generatePreservedRoutes, generateRegularRoutes } from './core'
 type Element = () => JSX.Element
 type Module = { default: Element; Loader: LoaderFn; Pending: Element; Catch: Element }
 
-// Avoid extglobs for rolldown-vite compatibility
-// ref: https://github.com/vitejs/rolldown-vite/issues/365
-const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
+const PRESERVED = import.meta.glob<Module>('/src/pages/{_app,404}.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>([
-  '/src/pages/**/[\\w[-]*.{jsx,tsx}',
-  '!/src/pages/**/_*.{jsx,tsx}',
+  '/src/pages/**/[A-Za-z0-9[-]*.{jsx,tsx}',
   '/src/pages/**/_layout.{jsx,tsx}',
-  '!/src/pages/**/404.{jsx,tsx}',
+  '!/src/pages/404.{jsx,tsx}',
+  '!/src/pages/**/_*/**',
 ])
 
 const preservedRoutes = generatePreservedRoutes<Module>(PRESERVED)

--- a/packages/generouted/src/react-router-lazy.tsx
+++ b/packages/generouted/src/react-router-lazy.tsx
@@ -7,15 +7,13 @@ import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } f
 type Element = () => JSX.Element
 type Module = { default: Element; Loader?: LoaderFunction; Action?: ActionFunction; Catch?: Element; Pending?: Element }
 
-// Avoid extglobs for rolldown-vite compatibility
-// ref: https://github.com/vitejs/rolldown-vite/issues/365
-const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
+const PRESERVED = import.meta.glob<Module>('/src/pages/{_app,404}.{jsx,tsx}', { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>([
-  '/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
-  '!/src/pages/**/_*.{jsx,tsx,mdx}',
+  '/src/pages/**/[A-Za-z0-9[-]*.{jsx,tsx,mdx}',
   '/src/pages/**/_layout.{jsx,tsx,mdx}',
-  '!/src/pages/**/404.{jsx,tsx,mdx}',
+  '!/src/pages/404.{jsx,tsx,mdx}',
+  '!/src/pages/**/_*/**',
 ])
 
 const preservedRoutes = generatePreservedRoutes<Omit<Module, 'Action'>>(PRESERVED)

--- a/packages/generouted/src/react-router-lazy.tsx
+++ b/packages/generouted/src/react-router-lazy.tsx
@@ -7,11 +7,15 @@ import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } f
 type Element = () => JSX.Element
 type Module = { default: Element; Loader?: LoaderFunction; Action?: ActionFunction; Catch?: Element; Pending?: Element }
 
-const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
+// Avoid extglobs for rolldown-vite compatibility
+// ref: https://github.com/vitejs/rolldown-vite/issues/365
+const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>([
   '/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
-  '!/src/pages/**/(_!(layout)*(/*)?|_app|404)*',
+  '!/src/pages/**/_*.{jsx,tsx,mdx}',
+  '/src/pages/**/_layout.{jsx,tsx,mdx}',
+  '!/src/pages/**/404.{jsx,tsx,mdx}',
 ])
 
 const preservedRoutes = generatePreservedRoutes<Omit<Module, 'Action'>>(PRESERVED)

--- a/packages/generouted/src/react-router.tsx
+++ b/packages/generouted/src/react-router.tsx
@@ -7,10 +7,17 @@ import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } f
 type Element = () => JSX.Element
 type Module = { default: Element; Loader?: LoaderFunction; Action?: ActionFunction; Catch?: Element; Pending?: Element }
 
-const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
+// Avoid extglobs for rolldown-vite compatibility
+// ref: https://github.com/vitejs/rolldown-vite/issues/365
+const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(
-  ['/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}', '!/src/pages/**/(_!(layout)*(/*)?|_app|404)*'],
+  [
+    '/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
+    '!/src/pages/**/_*.{jsx,tsx,mdx}',
+    '/src/pages/**/_layout.{jsx,tsx,mdx}',
+    '!/src/pages/**/404.{jsx,tsx,mdx}',
+  ],
   { eager: true },
 )
 

--- a/packages/generouted/src/react-router.tsx
+++ b/packages/generouted/src/react-router.tsx
@@ -7,16 +7,14 @@ import { generateModalRoutes, generatePreservedRoutes, generateRegularRoutes } f
 type Element = () => JSX.Element
 type Module = { default: Element; Loader?: LoaderFunction; Action?: ActionFunction; Catch?: Element; Pending?: Element }
 
-// Avoid extglobs for rolldown-vite compatibility
-// ref: https://github.com/vitejs/rolldown-vite/issues/365
-const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
+const PRESERVED = import.meta.glob<Module>('/src/pages/{_app,404}.{jsx,tsx}', { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(
   [
-    '/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
-    '!/src/pages/**/_*.{jsx,tsx,mdx}',
+    '/src/pages/**/[A-Za-z0-9[-]*.{jsx,tsx,mdx}',
     '/src/pages/**/_layout.{jsx,tsx,mdx}',
-    '!/src/pages/**/404.{jsx,tsx,mdx}',
+    '!/src/pages/404.{jsx,tsx,mdx}',
+    '!/src/pages/**/_*/**',
   ],
   { eager: true },
 )

--- a/packages/generouted/src/solid-router-lazy.tsx
+++ b/packages/generouted/src/solid-router-lazy.tsx
@@ -8,11 +8,15 @@ type CatchProps = { error: any; reset: () => void }
 type Module = { default: Component; Loader?: RouteLoadFunc; Catch?: Component<CatchProps>; Pending?: Component }
 type Route = { path?: string; component?: Component; children?: Route[] }
 
-const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
+// Avoid extglobs for rolldown-vite compatibility
+// ref: https://github.com/vitejs/rolldown-vite/issues/365
+const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>([
   '/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
-  '!/src/pages/**/(_!(layout)*(/*)?|_app|404)*',
+  '!/src/pages/**/_*.{jsx,tsx,mdx}',
+  '/src/pages/**/_layout.{jsx,tsx,mdx}',
+  '!/src/pages/**/404.{jsx,tsx,mdx}',
 ])
 
 const preservedRoutes = generatePreservedRoutes<Module>(PRESERVED)

--- a/packages/generouted/src/solid-router-lazy.tsx
+++ b/packages/generouted/src/solid-router-lazy.tsx
@@ -8,15 +8,13 @@ type CatchProps = { error: any; reset: () => void }
 type Module = { default: Component; Loader?: RouteLoadFunc; Catch?: Component<CatchProps>; Pending?: Component }
 type Route = { path?: string; component?: Component; children?: Route[] }
 
-// Avoid extglobs for rolldown-vite compatibility
-// ref: https://github.com/vitejs/rolldown-vite/issues/365
-const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
+const PRESERVED = import.meta.glob<Module>('/src/pages/{_app,404}.{jsx,tsx}', { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>([
-  '/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
-  '!/src/pages/**/_*.{jsx,tsx,mdx}',
+  '/src/pages/**/[A-Za-z0-9[-]*.{jsx,tsx,mdx}',
   '/src/pages/**/_layout.{jsx,tsx,mdx}',
-  '!/src/pages/**/404.{jsx,tsx,mdx}',
+  '!/src/pages/404.{jsx,tsx,mdx}',
+  '!/src/pages/**/_*/**',
 ])
 
 const preservedRoutes = generatePreservedRoutes<Module>(PRESERVED)

--- a/packages/generouted/src/solid-router.tsx
+++ b/packages/generouted/src/solid-router.tsx
@@ -8,10 +8,17 @@ type CatchProps = { error: any; reset: () => void }
 type Module = { default: Component; Loader?: RouteLoadFunc; Catch?: Component<CatchProps>; Pending?: Component }
 type RouteDef = { path?: string; component?: Component; children?: RouteDef[] }
 
-const PRESERVED = import.meta.glob<Module>('/src/pages/(_app|404).{jsx,tsx}', { eager: true })
+// Avoid extglobs for rolldown-vite compatibility
+// ref: https://github.com/vitejs/rolldown-vite/issues/365
+const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(
-  ['/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}', '!/src/pages/**/(_!(layout)*(/*)?|_app|404)*'],
+  [
+    '/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
+    '!/src/pages/**/_*.{jsx,tsx,mdx}',
+    '/src/pages/**/_layout.{jsx,tsx,mdx}',
+    '!/src/pages/**/404.{jsx,tsx,mdx}',
+  ],
   { eager: true },
 )
 

--- a/packages/generouted/src/solid-router.tsx
+++ b/packages/generouted/src/solid-router.tsx
@@ -8,16 +8,14 @@ type CatchProps = { error: any; reset: () => void }
 type Module = { default: Component; Loader?: RouteLoadFunc; Catch?: Component<CatchProps>; Pending?: Component }
 type RouteDef = { path?: string; component?: Component; children?: RouteDef[] }
 
-// Avoid extglobs for rolldown-vite compatibility
-// ref: https://github.com/vitejs/rolldown-vite/issues/365
-const PRESERVED = import.meta.glob<Module>(['/src/pages/_app.{jsx,tsx}', '/src/pages/404.{jsx,tsx}'], { eager: true })
+const PRESERVED = import.meta.glob<Module>('/src/pages/{_app,404}.{jsx,tsx}', { eager: true })
 const MODALS = import.meta.glob<Pick<Module, 'default'>>('/src/pages/**/[+]*.{jsx,tsx}', { eager: true })
 const ROUTES = import.meta.glob<Module>(
   [
-    '/src/pages/**/[\\w[-]*.{jsx,tsx,mdx}',
-    '!/src/pages/**/_*.{jsx,tsx,mdx}',
+    '/src/pages/**/[A-Za-z0-9[-]*.{jsx,tsx,mdx}',
     '/src/pages/**/_layout.{jsx,tsx,mdx}',
-    '!/src/pages/**/404.{jsx,tsx,mdx}',
+    '!/src/pages/404.{jsx,tsx,mdx}',
+    '!/src/pages/**/_*/**',
   ],
   { eager: true },
 )


### PR DESCRIPTION
Ref https://github.com/vitejs/rolldown-vite/issues/373

At current state, rolldown-vite does not have native module support for `extglob` yet making brace expansion, and exglobs not working.

This PR changes all braces, and extglobs expression into regular glob patterns.