### PR TITLE
fix: sort route keys in generateRegularRoutes for Rolldown compatibility

### DIFF
--- a/packages/generouted/src/core.ts
+++ b/packages/generouted/src/core.ts
@@ -20,7 +20,7 @@ export const generateRegularRoutes = <T extends BaseRoute, M>(
   files: Record<string, any>,
   buildRoute: (module: M, key: string) => T,
 ) => {
-  const filteredRoutes = Object.keys(files).filter((key) => !key.includes('/_') || /_layout\.(jsx|tsx)$/.test(key))
+  const filteredRoutes = Object.keys(files).filter((key) => !key.includes('/_') || /_layout\.(jsx|tsx)$/.test(key)).sort()
   return filteredRoutes.reduce<T[]>((routes, key) => {
     const module = files[key]
     const route = { id: key.replace(...patterns.route), ...buildRoute(module, key) }


### PR DESCRIPTION
## Summary

Fixes #208

`generateRegularRoutes` processes route files in the order returned by `Object.keys(files)`, which depends on the order `import.meta.glob` returns its keys. This works with Rollup (Vite 7), which returns keys alphabetically, but breaks with **Rolldown (Vite 8)**, which returns keys in a different order (directory-depth-first).

When a route has both a file and a subdirectory with the same name (a common pattern):

```
src/pages/alerts/[alert].tsx
src/pages/alerts/[alert]/[section].tsx
```

...and the subdirectory file is processed first, the `reduce` logic creates a skeleton parent node for `[alert]` **without** a `Component`. When `[alert].tsx` is processed later, it finds the existing node but never assigns its component — only `found.children` is ensured to exist. This causes React Router's error:

> Matched leaf route at location '/alerts/...' does not have an element or Component.

## Fix

Sort the filtered route keys before processing. This is a one-line change:

```diff
- const filteredRoutes = Object.keys(files).filter((key) => !key.includes('/_') || /_layout\.(jsx|tsx)$/.test(key))
+ const filteredRoutes = Object.keys(files).filter((key) => !key.includes('/_') || /_layout\.(jsx|tsx)$/.test(key)).sort()
```

No behavioral change for Rollup (which already returns sorted keys). Fixes Vite 8 / Rolldown compatibility.